### PR TITLE
fix: make panels explicitly rely on jquery

### DIFF
--- a/src/panels/flow-histogram/FlowHistogramControl.tsx
+++ b/src/panels/flow-histogram/FlowHistogramControl.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react'
+import $ from 'jquery'
 import { PanelProps } from '@grafana/data'
 import { UnitInfo } from './FlowHistogramConstants'
 import {

--- a/src/panels/flow-histogram/FlowHistogramHelpers.ts
+++ b/src/panels/flow-histogram/FlowHistogramHelpers.ts
@@ -1,4 +1,5 @@
 import { CSSProperties } from 'react'
+import $ from 'jquery'
 import { DataFrame, PanelData } from '@grafana/data'
 import { FlowHistogramOptionsProps, FlowPanelDataProcessed, FlowPanelUnitInfo } from './FlowHistogramTypes'
 import { DataPosition, FlowDataDirection, UnitInfo } from './FlowHistogramConstants'
@@ -50,7 +51,7 @@ export const getFlowHistogramPlotConfig = (
 
     const stacked = options.flowHistogramOptions.mode.label === 'Stacked'
     const horizontal = options.flowHistogramOptions.direction.label === 'Horizontal'
-    const container = null //options.flowHistogramOptions.position.label === 'Under Graph' ? $('.flow-histogram-legend-bottom') : $('.flow-histogram-legend-right') 
+    const container = null //options.flowHistogramOptions.position.label === 'Under Graph' ? $('.flow-histogram-legend-bottom') : $('.flow-histogram-legend-right')
     const noColumns = options.flowHistogramOptions.position.label === 'Under Graph' ? 5 : 1
     const showLegend = options.flowHistogramOptions.showLegend
     const legendPosition = options.flowHistogramOptions.position.value
@@ -176,7 +177,7 @@ const getMetricLabelsAndLabelFunction = (metric: string, frame: DataFrame) => {
 }
 
 /**
- * Returns and array of [index, label] 
+ * Returns and array of [index, label]
  * where index is the record position in the original data and the label to be displayed in the graph
  */
 export const getIndexedMetricLabels = (metricLabels: any[], labelFunction: LabelFunction, stacked: boolean) => {
@@ -286,7 +287,7 @@ export const getStyleFor = (element: FlowHistogramElement, height: number, width
             }
         case FlowHistogramElement.GraphAxisLabelUnit:
             return {
-                marginTop: 24 
+                marginTop: 24
             }
     }
 }


### PR DESCRIPTION
Some panel plugins in this app plugin rely on jQuery but because they don't explicitly import jQuery they rely on it living on the global object. When Grafana decides to remove jQuery from the global and only serve it via a lazy loaded chunk through its plugin loader these plugins will break.

The changes in this PR address this by adding jquery imports where usage is relying on global jquery.

# Pull Request Check Sheet

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [ ] Have you [made an issue in the OpenNMS issue tracker](https://opennms.atlassian.net/projects/OPG)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [ ] Have you made a comment in that issue which points back to this PR?
* [ ] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new feature, is there documentation?
* [ ] If this is a new feature or substantial change, are there tests that cover it?

# Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/${JIRA-ISSUE-NUMBER}
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
