### PR TITLE
OPG-526: Make the jQuery/flot dependency explicit, and related fixes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,13 @@
 // generally used by snapshots, but can affect specific tests
 process.env.TZ = 'UTC';
 
+// i18next prints a Locize marketing notice from init(), which @grafana/i18n and
+// @grafana/ui trigger on import. It is suppressed automatically when NODE_ENV is
+// 'production', but jest runs with NODE_ENV='test'. i18next removed the notice
+// entirely in v26, but @grafana/i18n and @grafana/ui both require i18next ^25.
+// https://github.com/i18next/i18next/issues/2407
+process.env.I18NEXT_NO_SUPPORT_NOTICE = '1';
+
 const { grafanaESModules, nodeModulesToTransform } = require('./.config/jest/utils');
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,6 @@
         "@grafana/schema": "^12.4.0",
         "@grafana/ui": "^12.4.0",
         "async": "^3.2.3",
-        "flot": "^0.8.3",
-        "flot-axislabels": "https://github.com/j-white/flot-axislabels#master",
         "lodash.clonedeep": "^4.5.0",
         "lodash.escaperegexp": "^4.1.2",
         "opennms": "^2.6.1",
@@ -9634,17 +9632,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
       "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "license": "ISC"
-    },
-    "node_modules/flot": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/flot/-/flot-0.8.3.tgz",
-      "integrity": "sha512-xg2otcTJDvS+ERK+my4wxG/ASq90QURXtoM4LhacCq0jQW2jbyjdttbRNqU2cPykrpMvJ6b2uSp6SAgYAzj9tQ=="
-    },
-    "node_modules/flot-axislabels": {
-      "name": "flot.axislabels",
-      "version": "2.0.1",
-      "resolved": "git+ssh://git@github.com/j-white/flot-axislabels.git#bf38a00da475e5fc7e6c672d4c37443ec4a5cfcf",
-      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",

--- a/package.json
+++ b/package.json
@@ -105,8 +105,6 @@
     "@grafana/schema": "^12.4.0",
     "@grafana/ui": "^12.4.0",
     "async": "^3.2.3",
-    "flot": "^0.8.3",
-    "flot-axislabels": "https://github.com/j-white/flot-axislabels#master",
     "lodash.clonedeep": "^4.5.0",
     "lodash.escaperegexp": "^4.1.2",
     "opennms": "^2.6.1",

--- a/src/panels/alarm-histogram/AlarmHistogramControl.tsx
+++ b/src/panels/alarm-histogram/AlarmHistogramControl.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import { PanelProps } from '@grafana/data'
 import $ from 'jquery'
+import 'jquery.flot'
 import { useAlarmHooks } from './alarmhooks'
 
 type SeriesSize = 'sm' | 'md' | 'lg'

--- a/src/panels/alarm-histogram/alarmhooks.ts
+++ b/src/panels/alarm-histogram/alarmhooks.ts
@@ -107,7 +107,6 @@ export const useAlarmHooks = () => {
                 }
             },
             [axis]: {
-                mode: 'categories',
                 tickLength: 0,
                 autoscaleMargin: 0.02,
                 ticks: getTicks(group)

--- a/src/panels/alarm-table/AlarmTableHelper.ts
+++ b/src/panels/alarm-table/AlarmTableHelper.ts
@@ -27,8 +27,10 @@ export const getAlarmIdFromRow = (row: Element, frame: DataFrame) => {
     const dataIndexCell = row?.children?.[columnIndex] || null
     const text = dataIndexCell?.textContent
 
+    // Number('') and Number(null) are both 0, which is an integer, so a blank
+    // cell would otherwise read as the invalid alarm id 0. Alarm ids start at 1.
     const alarmId = Number(text)
-    return Number.isInteger(alarmId) ? alarmId : -1
+    return Number.isInteger(alarmId) && alarmId > 0 ? alarmId : -1
   }
 
   return -1

--- a/src/panels/alarm-table/hooks/useAlarm.ts
+++ b/src/panels/alarm-table/hooks/useAlarm.ts
@@ -21,7 +21,7 @@ export const useAlarm = (series: DataFrame[], soloAlarmId: number, client: Clien
 
     useEffect(() => {
         const updateAlarm = async () => {
-            if (alarmId !== undefined && alarmId >= 0) {
+            if (alarmId !== undefined && alarmId > 0) {
               const returnedAlarm = await client?.getAlarm(alarmId)
               setAlarm(returnedAlarm)
             }

--- a/src/panels/alarm-table/hooks/useAlarmTableSelection.ts
+++ b/src/panels/alarm-table/hooks/useAlarmTableSelection.ts
@@ -50,7 +50,10 @@ export const useAlarmTableSelection = (doubleClicked) => {
                     newSelectedAlarmIds.add(rowAlarmIds[i])
                 }
 
-                setSoloAlarmId(0)
+                // a range is selected, so no single alarm is soloed. -1 is the
+                // 'nothing selected' sentinel used throughout; 0 would be passed
+                // on to useAlarm and fetched as the invalid alarm id 0
+                setSoloAlarmId(-1)
             } else if (fromContext && alarmId > 0) {
                 // user right-clicked on a row, toggling selection for that row
                 const countSelected = previousState.selectedAlarmIds.size

--- a/src/panels/flow-histogram/FlowHistogramControl.tsx
+++ b/src/panels/flow-histogram/FlowHistogramControl.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useRef } from 'react'
 import { PanelProps } from '@grafana/data'
+import $ from 'jquery'
+import 'jquery.flot'
+import 'jquery.flot.stack'
 import { UnitInfo } from './FlowHistogramConstants'
 import {
     FlowHistogramElement,

--- a/src/panels/flow-histogram/FlowHistogramControl.tsx
+++ b/src/panels/flow-histogram/FlowHistogramControl.tsx
@@ -20,6 +20,7 @@ interface Props extends PanelProps<FlowHistogramControlOptions> { }
 
 export const FlowHistogramControl: React.FC<Props> = ({ data, height, width, options }) => {
     const ref: any = useRef(undefined)
+    const legendRef = useRef<HTMLDivElement>(null)
 
     useEffect(() => {
         if (validateFlowHistogramPanelData(data?.series)) {
@@ -29,8 +30,7 @@ export const FlowHistogramControl: React.FC<Props> = ({ data, height, width, opt
 
           $.plot(ref.current, plotData, plotConfig)
 
-          // TODO: remove this fix once flot library is updated in grafana. Use container option in plotConfig instead
-          setLegend(options)
+          setLegend(ref.current, legendRef.current, options)
         }
     }, [data, width, height, ref, options])
 
@@ -73,7 +73,8 @@ export const FlowHistogramControl: React.FC<Props> = ({ data, height, width, opt
                         <p style={getStyleFor(FlowHistogramElement.GraphAxisLabelUnit, height, width, options)}>{UnitInfo(options, data?.series).units}</p>
                     </div>
                 </div>
-                <div className={(options.flowHistogramOptions.position.label === 'Under Graph' ? 'flow-histogram-legend-bottom' : 'flow-histogram-legend-right')}
+                <div ref={legendRef}
+                    className={(options.flowHistogramOptions.position.label === 'Under Graph' ? 'flow-histogram-legend-bottom' : 'flow-histogram-legend-right')}
                     style={getStyleFor(FlowHistogramElement.Legend, height, width, options)} />
             </div>
         </>

--- a/src/panels/flow-histogram/FlowHistogramHelpers.ts
+++ b/src/panels/flow-histogram/FlowHistogramHelpers.ts
@@ -1,6 +1,5 @@
 import { CSSProperties } from 'react'
 import { DataFrame, PanelData } from '@grafana/data'
-import $ from 'jquery'
 import { FlowHistogramOptionsProps, FlowPanelDataProcessed, FlowPanelUnitInfo } from './FlowHistogramTypes'
 import { DataPosition, FlowDataDirection, UnitInfo } from './FlowHistogramConstants'
 
@@ -51,13 +50,11 @@ export const getFlowHistogramPlotConfig = (
 
     const stacked = options.flowHistogramOptions.mode.label === 'Stacked'
     const horizontal = options.flowHistogramOptions.direction.label === 'Horizontal'
-    const container = null //options.flowHistogramOptions.position.label === 'Under Graph' ? $('.flow-histogram-legend-bottom') : $('.flow-histogram-legend-right') 
     const noColumns = options.flowHistogramOptions.position.label === 'Under Graph' ? 5 : 1
     const showLegend = options.flowHistogramOptions.showLegend
     const legendPosition = options.flowHistogramOptions.position.value
 
     const yaxis = {
-        mode: 'categories',
         tickLength: 0,
         ticks: stacked ? processedData.stackedData?.ticks : processedData.separateData?.ticks,
         autoscaleMargin: 0.02,
@@ -66,7 +63,9 @@ export const getFlowHistogramPlotConfig = (
     const configOptions = {
         legend: {
             show: showLegend,
-            container: container || undefined,
+            // No `container` here: flot renders the legend inside the plot and
+            // setLegend() moves it afterwards. See the note there for why flot's
+            // own `container` option cannot be used.
             position: legendPosition,
             backgroundOpacity: 0,
             noColumns: noColumns,
@@ -223,16 +222,36 @@ export const getSeriesMetricValues = (fields: any[], name: string) => {
     return match?.values?.toArray() || []
 }
 
-export const setLegend = (options: { flowHistogramOptions: FlowHistogramOptionsProps }) => {
-    if (options.flowHistogramOptions.showLegend) {
-        const className = options.flowHistogramOptions.position.label === 'Under Graph' ? '.flow-histogram-legend-bottom' : '.flow-histogram-legend-right'
-        const legend = $('.legend')
+// flot always renders its legend inside the plot container, so we move it into our
+// own element to position it independently of the graph.
+//
+// flot's `legend.container` option is meant to do exactly this, but it is broken in
+// the flot version Grafana vendors: insertLegend() clears the container with
+// `$.find(container).html('')`, and in jQuery 3.x `$.find` returns a plain Array,
+// which has no `.html()` - so it throws on every plot.
+//
+// Both elements are passed in rather than looked up by selector: two flow-histogram
+// panels on one dashboard would otherwise fight over the same document-wide match.
+export const setLegend = (
+    plotElement: HTMLElement | null,
+    legendElement: HTMLElement | null,
+    options: { flowHistogramOptions: FlowHistogramOptionsProps }
+) => {
+    if (!legendElement) {
+        return
+    }
 
-        if (legend && legend.html()) {
-            $(className).html('')
-            $(className).append(legend.html())
-            legend.remove()
-        }
+    if (!options.flowHistogramOptions.showLegend) {
+        // clear anything a previous render moved here
+        legendElement.replaceChildren()
+        return
+    }
+
+    const legend = plotElement?.querySelector('.legend')
+
+    if (legend?.hasChildNodes()) {
+        legendElement.replaceChildren(...legend.childNodes)
+        legend.remove()
     }
 }
 

--- a/src/panels/flow-histogram/FlowHistogramHelpers.ts
+++ b/src/panels/flow-histogram/FlowHistogramHelpers.ts
@@ -1,5 +1,6 @@
 import { CSSProperties } from 'react'
 import { DataFrame, PanelData } from '@grafana/data'
+import $ from 'jquery'
 import { FlowHistogramOptionsProps, FlowPanelDataProcessed, FlowPanelUnitInfo } from './FlowHistogramTypes'
 import { DataPosition, FlowDataDirection, UnitInfo } from './FlowHistogramConstants'
 

--- a/src/test/react/alarm_table_solo_alarm.spec.ts
+++ b/src/test/react/alarm_table_solo_alarm.spec.ts
@@ -1,0 +1,99 @@
+import { renderHook, act } from '@testing-library/react'
+import { DataFrame } from '@grafana/data'
+import { useAlarm } from '../../panels/alarm-table/hooks/useAlarm'
+import { useAlarmTableSelection } from '../../panels/alarm-table/hooks/useAlarmTableSelection'
+import { getAlarmIdFromRow, getAlarmIdsForRows } from '../../panels/alarm-table/AlarmTableHelper'
+
+// Alarm IDs in OpenNMS always start at 1, so 0 is never a real alarm. -1 is the
+// codebase's "nothing selected" sentinel.
+
+const alarmFrame = (): DataFrame => ({ name: 'alarms', fields: [{ name: 'ID' } as any], length: 0 })
+
+const rowWithIdText = (text: string | null) => {
+  const row = document.createElement('div')
+  row.setAttribute('role', 'row')
+  const cell = document.createElement('div')
+
+  if (text !== null) {
+    cell.textContent = text
+  }
+
+  row.appendChild(cell)
+  return row
+}
+
+describe('AlarmTableHelper :: getAlarmIdFromRow', () => {
+  it('should read a real alarm id', () => {
+    expect(getAlarmIdFromRow(rowWithIdText('9839'), alarmFrame())).toEqual(9839)
+  })
+
+  it('should return -1, never 0, for a blank or missing id cell', () => {
+    // Number('') and Number(null) are both 0, and Number.isInteger(0) is true,
+    // so an unguarded conversion yields a bogus alarm id of 0
+    for (const text of ['', '   ', null]) {
+      expect(getAlarmIdFromRow(rowWithIdText(text), alarmFrame())).toEqual(-1)
+    }
+  })
+
+  it('should return -1 for non-numeric text', () => {
+    expect(getAlarmIdFromRow(rowWithIdText('ID'), alarmFrame())).toEqual(-1)
+  })
+
+  it('should never put a 0 into the ids collected for a row range', () => {
+    const rows = [rowWithIdText('9839'), rowWithIdText(''), rowWithIdText('9700')]
+
+    expect(getAlarmIdsForRows(rows, alarmFrame())).not.toContain(0)
+  })
+})
+
+describe('useAlarm', () => {
+  const client = { getAlarm: jest.fn().mockResolvedValue({ id: 1 }) }
+  const series = [{ name: 'alarms', fields: [], length: 0 }] as DataFrame[]
+
+  beforeEach(() => client.getAlarm.mockClear())
+
+  it('should fetch a real alarm', async () => {
+    // awaited so the resolved setAlarm() settles inside act()
+    await act(async () => { renderHook(() => useAlarm(series, 9839, client as any)) })
+
+    expect(client.getAlarm).toHaveBeenCalledWith(9839)
+  })
+
+  it('should not request alarm 0', () => {
+    renderHook(() => useAlarm(series, 0, client as any))
+    expect(client.getAlarm).not.toHaveBeenCalled()
+  })
+
+  it('should not request an alarm when nothing is selected', () => {
+    renderHook(() => useAlarm(series, -1, client as any))
+    expect(client.getAlarm).not.toHaveBeenCalled()
+  })
+})
+
+describe('useAlarmTableSelection :: multi-row selection', () => {
+  const frame = alarmFrame()
+  const rows = [rowWithIdText('101'), rowWithIdText('102'), rowWithIdText('103')]
+  const click = (shiftKey = false) => ({ shiftKey, ctrlKey: false, detail: 1 }) as MouseEvent
+  const table = document.createElement('div')
+
+  it('should solo the clicked alarm on a plain click', () => {
+    const { result } = renderHook(() => useAlarmTableSelection(jest.fn()))
+
+    act(() => { result.current.rowClicked(table, 101, click(), rows, frame) })
+
+    expect(result.current.soloAlarmId).toEqual(101)
+  })
+
+  it('should clear the solo alarm to -1 when a row range is selected', () => {
+    const { result } = renderHook(() => useAlarmTableSelection(jest.fn()))
+
+    act(() => { result.current.rowClicked(table, 101, click(), rows, frame) })
+    act(() => { result.current.rowClicked(table, 103, click(true), rows, frame) })
+
+    // multiple rows are selected, so no single alarm is soloed. Must be the -1
+    // sentinel: 0 would be forwarded to useAlarm and fetched as api/v2/alarms/0
+    expect(result.current.soloAlarmId).toEqual(-1)
+    expect(result.current.soloAlarmId).not.toEqual(0)
+    expect(result.current.alarmControlState.selectedAlarmIds.size).toBeGreaterThan(1)
+  })
+})

--- a/src/test/react/flow_histogram_legend.spec.ts
+++ b/src/test/react/flow_histogram_legend.spec.ts
@@ -1,0 +1,84 @@
+import { setLegend } from '../../panels/flow-histogram/FlowHistogramHelpers'
+
+// Minimal stand-in for the panel options setLegend actually reads.
+const optionsWith = (showLegend: boolean) =>
+  ({ flowHistogramOptions: { showLegend } }) as any
+
+// Mirrors the DOM flot produces: a `.legend` rendered inside the plot container.
+const makePlot = (legendMarkup?: string) => {
+  const plot = document.createElement('div')
+
+  if (legendMarkup !== undefined) {
+    const legend = document.createElement('div')
+    legend.className = 'legend'
+    legend.innerHTML = legendMarkup
+    plot.appendChild(legend)
+  }
+
+  return plot
+}
+
+describe('FlowHistogramHelpers :: setLegend', () => {
+  it('should move the flot legend out of the plot and into the legend element', () => {
+    const plot = makePlot('<table><tbody><tr><td>in</td></tr></tbody></table>')
+    const legendElement = document.createElement('div')
+
+    setLegend(plot, legendElement, optionsWith(true))
+
+    expect(legendElement.querySelector('table')).not.toBeNull()
+    expect(legendElement.textContent).toEqual('in')
+    // the now-empty flot legend wrapper is removed from the plot
+    expect(plot.querySelector('.legend')).toBeNull()
+  })
+
+  it('should replace content from a previous render rather than appending to it', () => {
+    const legendElement = document.createElement('div')
+    legendElement.innerHTML = '<table><tbody><tr><td>stale</td></tr></tbody></table>'
+
+    setLegend(makePlot('<table><tbody><tr><td>fresh</td></tr></tbody></table>'), legendElement, optionsWith(true))
+
+    expect(legendElement.textContent).toEqual('fresh')
+    expect(legendElement.querySelectorAll('table').length).toEqual(1)
+  })
+
+  it('should clear a previously moved legend when the legend is turned off', () => {
+    const legendElement = document.createElement('div')
+    legendElement.innerHTML = '<table><tbody><tr><td>stale</td></tr></tbody></table>'
+
+    setLegend(makePlot(), legendElement, optionsWith(false))
+
+    expect(legendElement.hasChildNodes()).toEqual(false)
+  })
+
+  it('should leave the legend element alone when flot rendered no legend', () => {
+    const legendElement = document.createElement('div')
+
+    setLegend(makePlot(), legendElement, optionsWith(true))
+    setLegend(makePlot(''), legendElement, optionsWith(true))
+
+    expect(legendElement.hasChildNodes()).toEqual(false)
+  })
+
+  it('should not throw before the refs are attached', () => {
+    expect(() => setLegend(null, null, optionsWith(true))).not.toThrow()
+    expect(() => setLegend(makePlot('<table></table>'), null, optionsWith(true))).not.toThrow()
+  })
+
+  it('should only touch the panel it was given, not other panels on the dashboard', () => {
+    // the previous implementation used document-wide selectors, so a second panel
+    // would steal the first panel's legend
+    const plotA = makePlot('<table><tbody><tr><td>panel A</td></tr></tbody></table>')
+    const plotB = makePlot('<table><tbody><tr><td>panel B</td></tr></tbody></table>')
+    const legendA = document.createElement('div')
+    const legendB = document.createElement('div')
+    document.body.append(plotA, plotB, legendA, legendB)
+
+    setLegend(plotA, legendA, optionsWith(true))
+    setLegend(plotB, legendB, optionsWith(true))
+
+    expect(legendA.textContent).toEqual('panel A')
+    expect(legendB.textContent).toEqual('panel B')
+
+    document.body.replaceChildren()
+  })
+})

--- a/src/types/flot-modules.d.ts
+++ b/src/types/flot-modules.d.ts
@@ -1,0 +1,12 @@
+// Grafana exposes flot to plugins through its SystemJS shared-dependency map
+// (see `jQueryFlotDeps` in Grafana's `sharedDependencies.ts`). These modules are
+// side-effect only: importing one makes Grafana load flot and patch it onto the
+// shared jQuery instance, which is what provides `$.plot`.
+//
+// Importing them explicitly matters as of grafana/grafana#131346, which drops
+// jQuery and flot from Grafana's boot path and loads them on demand instead.
+// Before that change flot was always attached to jQuery by the time a plugin
+// loaded; after it, a plugin that never imports these gets a jQuery with no
+// `.plot`.
+declare module 'jquery.flot'
+declare module 'jquery.flot.stack'

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -15,6 +15,14 @@ const config = async (env): Promise<Configuration> => {
     output: {
       hashFunction: 'sha256',
     },
+    // Grafana serves flot to plugins from its SystemJS shared-dependency map, the
+    // same way it serves 'jquery' (which .config/bundler/externals.ts already lists).
+    // The alarm-histogram and flow-histogram panels import these for their side
+    // effect, to make Grafana attach flot to the shared jQuery so `$.plot` exists.
+    externals: [
+      'jquery.flot',
+      'jquery.flot.stack',
+    ],
     plugins: [
       // add README.md to datasources, this is what is displayed when clicking the "?" next to
       // a datasource in the query editor.


### PR DESCRIPTION
# OPG-526: Make the jQuery/flot dependency explicit, and related fixes

## Why

Grafana has historically loaded jQuery and flot globally at boot, and our Alarm and Flow
histogram panels relied on that. Grafana is considering removing both from the
boot path ([grafana/grafana#131346](https://github.com/grafana/grafana/pull/131346)),
which would break those panels. This branch makes the dependency explicit
so the panels keep working, and cleans up a few things found along the way.

**jQuery is not going away.** It stays available to plugins — Grafana is only
making it load on demand. So we do not need to bundle our own copy, and nothing
here changes what ships in the plugin bundle.

## What changed

### 1. Declare jQuery and flot explicitly

Both panels now import what they use explicitly, and the flot modules are marked external so Grafana keeps serving them.

Also removed the `flot` and `flot-axislabels` dependencies: nothing in `src/`
ever imported them. This drops a git-URL dependency on a personal fork.

### 2. Remove jQuery from the flow-histogram legend

`setLegend()` was the last jQuery use outside the two chart calls, and it used
document-wide selectors — so two flow-histogram panels on one dashboard would
fight over the same legend. It is now plain DOM, scoped per panel instance.

The standing TODO suggested using flot's own `legend.container` option instead.
That option is broken in the flot version Grafana vendors and throws on every
render; the TODO has been replaced with the reason.

Remaining jQuery footprint is now exactly two `$.plot()` calls.

### 3. Stop requesting the invalid alarm ID `0`

Selecting a range of rows in the Alarm Table fired a request for
`api/v2/alarms/0`, which 404s. The range-selection branch used `0` to mean
"nothing selected" where the rest of the code uses `-1`. Fixed at both ends —
the assignment and the guard that let it through.

Also hardened the row ID parser, which returned `0` rather than `-1` for a blank
cell. That could previously put `0` into the selection set, so a bulk
acknowledge or clear would act on alarm `0`.

### 4. Silence the i18next Locize notice in tests

`i18next` prints a marketing notice on init, which appeared once per test suite.
It is a transitive dependency via `@grafana/i18n` and `@grafana/ui`, and is external at
runtime, so this was test-only noise. Opted out via an env var in `jest.config.js`.

The notice was removed in i18next v26, but both Grafana packages require `^25`,
so upgrading was not worth the risk for no runtime benefit.

## Testing

Unit tests added. Both panels tested and work in Grafana 9, 10, 11, 12, and 13.

## Notes

- Not addressed, and unchanged in behaviour: a background right-click leaves
  `lastClickedAlarmId` at `0`, which makes the next shift-click select a single
  row rather than extend the range. Fixing it needs the branch condition
  reworked; worth doing only if users have noticed.


# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-526
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
