### PR TITLE
OPG-529: Audit the deb and zip builders and make them testable

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -192,7 +192,11 @@ Monitor https://community.grafana.com/t/build-a-panel-plugin-error/100984/3 for 
   `/usr/lib` with a bogus service unit instead of into the Grafana plugin directory
 - Only includes `dist/` in the RPM (not `node_modules`), minus the entries in
   `scripts/distContents.js`
-- Set `MAKERPM_DEBUG=1` for CircleCI debugging
+- Set `MAKERPM_DEBUG=1` for CircleCI debugging (`MAKEDEB_DEBUG` / `MAKEZIP_DEBUG` for the
+  other two)
+- The deb and zip follow the same shape: a thin entry point over a testable
+  `scripts/<type>/build.js`, staging via `scripts/stageDist.js` and publishing via
+  `scripts/artifacts.js`. Neither builds inside `artifacts/`
 
 ## Support Matrix
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,14 @@ A full reinstall also re-resolves every `^` range, so it can surface breakage un
   `src/` into `dist` and `npm run sign` attests everything in `dist`
 - CI invokes the `npm run package:*` scripts, so entry-point paths are not hardcoded in
   `.circleci/config.yml`
-- `MAKERPM_DEBUG=1` turns on verbose `make-rpm.js` output for CircleCI debugging
+- `MAKERPM_DEBUG=1` / `MAKEDEB_DEBUG=1` / `MAKEZIP_DEBUG=1` turn on verbose output for
+  CircleCI debugging. Each entry point is a thin wrapper; the work lives in a sibling
+  `build.js` that takes paths as arguments so it can be tested against a fixture `dist`
+- The deb builds under the system temp directory, never under `artifacts/`.
+  `dpkg-buildpackage` writes a `.dsc`, `.changes`, `.buildinfo` and source tarball beside the
+  `.deb`, and only the `.deb` is signed and published; building in `artifacts/` shipped all of
+  them to CI and left a full copy of `dist` there on failure. Each builder cleans its working
+  tree in a `finally`, not on the success path only
 - `make-rpm.js` renders `scripts/rpm/spec.mustache` itself. Do **not** reintroduce `speculate`: 6.x
   hardcodes its own systemd-service spec template and ignores `spec.specTemplate` /
   `spec.installDir`, which silently packaged the plugin into `/usr/lib` with a bogus service

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -69,9 +69,7 @@ tested:
 | --- | --- |
 | `scripts/rpm/spec.js` | Renders `scripts/rpm/spec.mustache` into a spec file |
 | `scripts/rpm/archive.js` | Packs the `dist` tree into the source tarball rpmbuild consumes |
-| `scripts/rpm/build.js` | Lays out an rpmbuild tree, runs rpmbuild, publishes the artifact |
-| `scripts/packageVersion.js` | Derives version and release from `package.json` (shared with `make-deb.js`) |
-| `scripts/distContents.js` | What belongs in a package built from `dist` (shared with `make-deb.js` and `make-zip.js`) |
+| `scripts/rpm/build.js` | Lays out an rpmbuild tree, runs rpmbuild, returns the built rpm |
 
 The `spec` section of `package.json` supplies `specTemplate`, `installDir` and `requires`.
 
@@ -98,7 +96,57 @@ that a `package.json` can be required from the directory it is given. That is wh
 here — it was being handed `dist`, which has no `package.json` — and it tells us nothing that
 `make-rpm.js` does not already know, so it is not used.
 
-### Package contents
+## make-deb.js
+
+`make-deb.js` stages `dist` with a generated `debian/` directory beside it and runs
+`dpkg-buildpackage`. Like the rpm it is a thin wrapper over testable modules:
+
+| Module | Responsibility |
+| --- | --- |
+| `scripts/deb/build.js` | Stages the build tree, runs dpkg-buildpackage, publishes the deb |
+| `scripts/deb/metadata.js` | Renders `debian/control` and the changelog |
+| `scripts/deb/maintainer.js` | Resolves the maintainer identity from `DEBFULLNAME`/`DEBEMAIL` |
+
+`Depends` is derived from the same `package.json` `spec.requires` the rpm's `Requires` comes
+from, so the two cannot disagree about which Grafana the plugin needs.
+
+The build happens in a directory under the system temp directory, **not** under `artifacts/`.
+`dpkg-buildpackage` writes a `.dsc`, a `.changes`, a `.buildinfo` and a source tarball beside
+the `.deb`, and only the `.deb` is signed and published; building in `artifacts/` meant CI
+stored all of them, and left a full copy of `dist` there whenever a build failed.
+
+Set `MAKEDEB_DEBUG=1` for verbose output, including dpkg-buildpackage's own output.
+
+## make-zip.js
+
+`make-zip.js` stages `dist` into a directory named for the plugin id and zips that directory —
+Grafana identifies a plugin by the zip's top-level directory name. `scripts/zip/build.js` holds
+the work.
+
+The zip is named with the raw `package.json` version, so a snapshot build keeps its snapshot
+suffix in the filename. That is deliberate: the rpm and deb split the version into version and
+release because their packaging formats need it for sort order, and a zip has no such
+semantics. Keeping the suffix also distinguishes a snapshot from a release, which a bare
+version with a release number of 0 would not.
+
+Set `MAKEZIP_DEBUG=1` for verbose output, including zip's own output.
+
+## Shared packaging modules
+
+| Module | Responsibility |
+| --- | --- |
+| `scripts/paths.js` | `PROJECT_DIR` and `DEBIAN_DIR`, resolved from the file's own location |
+| `scripts/packageVersion.js` | Derives version and release from `package.json` (rpm and deb) |
+| `scripts/distContents.js` | What belongs in a package built from `dist` (all three) |
+| `scripts/stageDist.js` | Copies `dist` into a staging directory, applying that list (deb and zip) |
+| `scripts/artifacts.js` | Publishes a built package into `artifacts/` (all three) |
+
+All three builders resolve their paths from `scripts/paths.js` rather than `process.cwd()`, so
+they work from any working directory, and each removes its own working tree in a `finally`
+rather than only on the success path.
+
+
+## Package contents
 
 Only the contents of `dist` belong in the package, so the source tarball is rooted at `dist`
 and the spec's `%install` copies the archive root. `scripts/distContents.js` lists what never
@@ -120,12 +168,25 @@ The packaging scripts apply the same list as a second line of defence. That is n
 for `test`, but it still matters for the `SPECS`/`SOURCES` directories the RPM build creates
 inside `dist` while it runs.
 
-### Tests
+## Packaging tests
 
-`src/test/packaging/` covers spec rendering, the source archive, the shared exclusions and a
-full `rpmbuild` run whose output is interrogated with `rpm -qp`. The end-to-end tests skip
-themselves when `rpmbuild` is not on `PATH`, so they run locally and on a build host but not
-in the plain test job.
+`src/test/packaging/` covers all three builders: spec rendering and the source archive for the
+rpm, `debian/control` and changelog rendering and build-tree staging for the deb, the shared
+`dist` exclusions and staging, and the resolved packaging paths.
+
+The end-to-end tests build a real package from a fixture `dist` and interrogate the result —
+`rpm -qp` for the rpm, `unzip -Z1` for the zip. Each skips itself when its tool is not on
+`PATH`: `rpmbuild` and `zip` are usually present on a developer machine, `dpkg-buildpackage`
+generally is not, so the deb's end-to-end tests skip outside a Debian build host. To run those,
+use the CI image:
+
+```bash
+docker run --rm -v "$PWD":/work -w /work opennms/build-env:debian-jdk11-b10453 \
+  bash -lc './scripts/deb/make-deb.js --release 1'
+```
+
+Note that the jest suite is not currently run by `.circleci/config.yml` at all, so every one of
+these tests is a local-and-pre-commit check rather than a CI gate.
 
 
 ## grafana/plugin-validator

--- a/scripts/artifacts.js
+++ b/scripts/artifacts.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// Publishes a built package where CI's sign and publish steps look for it. Shared by
+// the rpm, deb and zip builders so all three land their output the same way.
+
+const fs = require('fs');
+const path = require('path');
+
+// Overwrites rather than skipping, so a rebuild at the same version cannot silently
+// ship a stale package.
+function copyToArtifacts(packagePath, artifactsDir) {
+  const target = path.join(artifactsDir, path.basename(packagePath));
+
+  fs.mkdirSync(artifactsDir, { recursive: true });
+  fs.rmSync(target, { force: true });
+  fs.copyFileSync(packagePath, target);
+
+  return target;
+}
+
+module.exports = { copyToArtifacts };

--- a/scripts/deb/build.js
+++ b/scripts/deb/build.js
@@ -1,0 +1,141 @@
+'use strict';
+
+// Drives dpkg-buildpackage end to end: stages dist/ with a generated debian/ directory
+// beside it and runs the build. Paths are arguments rather than being read from
+// process.cwd() so the whole pipeline can be exercised against a fixture dist.
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const copy = require('recursive-copy');
+const which = require('which');
+
+const { copyToArtifacts } = require('../artifacts');
+const { DEBIAN_DIR } = require('../paths');
+const { stageDist } = require('../stageDist');
+const { renderChangelog, renderControl } = require('./metadata');
+
+function findDpkgBuildpackage() {
+  return which.sync('dpkg-buildpackage', { nothrow: true });
+}
+
+// dpkg-buildpackage writes its output to the parent of the directory it builds in, so
+// the .deb lands beside a .dsc, a .changes, a .buildinfo and a source tarball. Only the
+// .deb is published, and reconstructing its name gets the architecture suffix wrong, so
+// ask the filesystem instead.
+function findBuiltDebs(dir) {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(dir)
+    .filter((file) => file.endsWith('.deb'))
+    .map((file) => path.join(dir, file));
+}
+
+async function stageDebTree({
+  distDir,
+  workDir,
+  pkgInfo,
+  version,
+  release,
+  maintainer,
+  debianDir = DEBIAN_DIR
+}) {
+  const staged = await stageDist({ distDir, targetDir: workDir });
+
+  const debian = path.join(workDir, 'debian');
+  fs.mkdirSync(debian, { recursive: true });
+
+  // The templates are rendered below; copying them through as-is would both ship a
+  // stray .mustache in the package and leave dpkg reading an unrendered control.
+  await copy(debianDir, debian, { filter: ['**/*', '!**/*.mustache'] });
+
+  fs.writeFileSync(path.join(debian, 'control'), renderControl({ pkgInfo, maintainer }));
+  fs.writeFileSync(
+    path.join(debian, 'changelog'),
+    renderChangelog({ pkgInfo, version, release, maintainer })
+  );
+
+  return staged;
+}
+
+// Publishes into artifactsDir itself rather than handing the caller a path under
+// buildRoot, because buildRoot is removed on the way out: the deb has to be copied out
+// while it still exists, and doing that here is what lets the cleanup be unconditional.
+async function buildDeb({
+  distDir,
+  buildRoot,
+  artifactsDir,
+  pkgInfo,
+  pluginInfo,
+  version,
+  release,
+  maintainer,
+  verbose = false
+}) {
+  const log = verbose ? (...args) => console.log(...args) : () => {};
+
+  const dpkgBuildpackage = findDpkgBuildpackage();
+
+  if (!dpkgBuildpackage) {
+    throw new Error('make-deb: dpkg-buildpackage executable not found on PATH');
+  }
+
+  // buildRoot is ours to own: starting from empty is what makes the deb produced by
+  // this build unambiguous below, and it is deliberately not artifacts/ — building
+  // there left a full copy of dist where CI collects artifacts whenever a build failed.
+  fs.rmSync(buildRoot, { recursive: true, force: true });
+
+  try {
+    const workDir = path.join(buildRoot, pluginInfo.id);
+
+    log('Staging the deb tree in ' + workDir);
+    const staged = await stageDebTree({ distDir, workDir, pkgInfo, version, release, maintainer });
+    log(staged + ' files staged, debian/ written for ' + maintainer);
+
+    log('Running dpkg-buildpackage in ' + workDir);
+    // -us -uc: do not sign the .dsc/.changes here. dpkg-buildpackage would sign as the
+    // changelog's maintainer identity, which is not a key we hold; CI signs the built
+    // .deb separately with the OpenNMS release key. Before make-deb.js checked the exit
+    // status, that signing failure (status 25) was discarded and the build looked green.
+    const result = spawnSync(dpkgBuildpackage, ['-us', '-uc'], {
+      cwd: workDir,
+      stdio: verbose ? ['inherit', 'inherit', 'inherit'] : ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf-8'
+    });
+
+    if (result.error) {
+      throw new Error('make-deb: dpkg-buildpackage could not be run: ' + result.error.message);
+    }
+
+    // spawnSync reports a non-zero exit only in `status`, never in `error`.
+    if (result.status !== 0) {
+      throw new Error(
+        'make-deb: dpkg-buildpackage exited with status ' +
+          result.status +
+          '\n' +
+          (result.stderr || result.stdout || '')
+      );
+    }
+
+    const debs = findBuiltDebs(buildRoot);
+
+    if (debs.length !== 1) {
+      throw new Error(
+        'make-deb: expected exactly one deb under ' +
+          buildRoot +
+          ', found ' +
+          debs.length +
+          (debs.length ? ': ' + debs.join(', ') : '')
+      );
+    }
+
+    return { debPath: copyToArtifacts(debs[0], artifactsDir) };
+  } finally {
+    fs.rmSync(buildRoot, { recursive: true, force: true });
+  }
+}
+
+module.exports = { buildDeb, findBuiltDebs, findDpkgBuildpackage, stageDebTree };

--- a/scripts/deb/make-deb.js
+++ b/scripts/deb/make-deb.js
@@ -1,106 +1,82 @@
 #!/usr/bin/env node
 
-/* jshint esversion: 6 */
+// Builds the DEB for the OpenNMS plugin for Grafana.
+//
+// The work lives in the sibling build module so it can be unit tested; this file only
+// resolves the real paths and package metadata and reports the result.
+//
+// Set MAKEDEB_DEBUG=1 for verbose output (dpkg-buildpackage's own output and the
+// staging progress) when debugging a CI build.
 
-const fs = require('fs-extra');
+const os = require('os');
 const path = require('path');
-const spawn = require('child_process').spawnSync;
-const copy = require('recursive-copy');
-const rimraf = require('rimraf');
-const which = require('which');
+
 const program = require('commander');
 
-const { recursiveCopyFilter } = require('../distContents');
-const { DEBIAN_DIR, PROJECT_DIR } = require('../paths');
-const { resolveMaintainer } = require('./maintainer');
-const { renderChangelog, renderControl } = require('./metadata');
+const { PROJECT_DIR } = require('../paths');
 const { resolveVersionAndRelease } = require('../packageVersion');
-const pkginfo = require('../../package.json');
-const plugininfo = require('../../src/plugin.json');
+const { buildDeb, findDpkgBuildpackage } = require('./build');
+const { resolveMaintainer } = require('./maintainer');
+const pkgInfo = require('../../package.json');
+const pluginInfo = require('../../src/plugin.json');
 
-try {
-  which.sync('dpkg-buildpackage');
-} catch (err) {
-  console.log('dpkg-buildpackage executable not found');
-  process.exit(1);
-}
+const isDebug = process.env.MAKEDEB_DEBUG === '1';
 
-const { version, release: defaultRelease } = resolveVersionAndRelease(pkginfo.version);
+const distDir = path.join(PROJECT_DIR, 'dist');
+const artifactsDir = path.join(PROJECT_DIR, 'artifacts');
+// Deliberately not under artifacts/: dpkg-buildpackage writes a .dsc, a .changes, a
+// .buildinfo and a source tarball beside the .deb, and building in artifacts/ meant CI
+// stored all of them, plus a full copy of dist whenever a build failed.
+const buildRoot = path.join(os.tmpdir(), 'opennms-grafana-plugin-deb');
+
+const { version, release: defaultRelease } = resolveVersionAndRelease(pkgInfo.version);
 
 program
-  .version(pkginfo.version)
+  .version(pkgInfo.version)
   .option('-r --release <release>', 'Specify release number of package', defaultRelease)
   .parse(process.argv);
 
 const release = program.opts().release;
 
-pkginfo.version = version;
-pkginfo.release = release;
-
-
 // debian/control and the changelog trailer must name the same identity, so both are
 // generated from one value. DEBFULLNAME/DEBEMAIL override it.
 const maintainer = resolveMaintainer();
 
-const pkgid   = plugininfo.id;
-const workdir = path.join(PROJECT_DIR, 'artifacts', pkgid);
-const distdir = path.join(PROJECT_DIR, 'dist');
+async function main() {
+  if (!findDpkgBuildpackage()) {
+    console.error('dpkg-buildpackage executable not found');
+    process.exit(1);
+  }
 
-rimraf.sync(workdir);
-fs.mkdirsSync(workdir);
-return copy(distdir, workdir, {
-  dot: true,
-  junk: false,
-  filter: recursiveCopyFilter([
-    '!**/*.changes',
-    '!**/*.deb',
-    '!**/*.dsc',
-    '!**/*.tar.gz',
-  ])
-}).then((results) => {
-  console.log(results.length + ' files copied to ' + workdir);
+  console.log(
+    'Building DEB for ' + pluginInfo.name + ' (' + pluginInfo.id + ') ' + version + '-' + release
+  );
 
-  const debian = path.join(workdir, 'debian');
-  fs.mkdirsSync(debian);
+  let debPath;
 
-  // The templates are rendered below; they must not be copied through as-is.
-  return copy(DEBIAN_DIR, debian, {
-    filter: ['**/*', '!**/*.mustache']
-  }).then((_copyResults) => {
-    console.log('debian/ directory copied');
+  try {
+    ({ debPath } = await buildDeb({
+      distDir,
+      buildRoot,
+      artifactsDir,
+      pkgInfo,
+      pluginInfo,
+      version,
+      release,
+      maintainer,
+      verbose: isDebug
+    }));
+  } catch (err) {
+    console.error('DEB generation failed: ' + err.message);
+    process.exit(1);
+  }
 
-    console.log('* writing control and changelog for ' + maintainer);
-    fs.writeFileSync(path.join(debian, 'control'), renderControl({ pkgInfo: pkginfo, maintainer }));
-    fs.writeFileSync(
-      path.join(debian, 'changelog'),
-      renderChangelog({ pkgInfo: pkginfo, version, release, maintainer })
-    );
+  console.log('Wrote ' + debPath);
+}
 
-    console.log('* running dpkg-buildpackage');
-    // -us -uc: do not sign the .dsc/.changes here. dpkg-buildpackage would sign as the
-    // changelog's maintainer identity, which is not a key we hold; CI signs the built
-    // .deb separately with the OpenNMS release key. Before make-deb.js checked the exit
-    // status, that signing failure (status 25) was discarded and the build looked green.
-    const ret = spawn('dpkg-buildpackage', ['-us', '-uc'], {
-      cwd: workdir,
-      stdio: ['inherit', 'inherit', 'inherit'],
-    });
-    if (ret.error) {
-      console.log('dpkg-buildpackage failed: ' + ret.error.message);
-      process.exit(1);
-    }
-
-    // spawnSync reports a non-zero exit only in `status`, never in `error`.
-    if (ret.status !== 0) {
-      console.log('dpkg-buildpackage exited with status ' + ret.status);
-      process.exit(1);
-    }
-
-    rimraf.sync(workdir);
-
-    process.exit(0);
-  });
-}).catch((error) => {
-  console.log('Copy failed: ' + error);
+// Backstop: anything thrown outside the try above (or from an async rejection)
+// should still report as a build failure rather than an unhandled rejection.
+main().catch((err) => {
+  console.error('DEB generation failed: ' + err.message);
   process.exit(1);
 });

--- a/scripts/rpm/build.js
+++ b/scripts/rpm/build.js
@@ -136,16 +136,5 @@ function buildRpm({
     .finally(cleanDist);
 }
 
-// Publishes the built rpm where CI's publish step looks for it. Overwrites rather
-// than skipping, so a rebuild at the same version cannot silently ship a stale rpm.
-function copyToArtifacts(rpmPath, artifactsDir) {
-  const target = path.join(artifactsDir, path.basename(rpmPath));
 
-  fs.mkdirSync(artifactsDir, { recursive: true });
-  fs.rmSync(target, { force: true });
-  fs.copyFileSync(rpmPath, target);
-
-  return target;
-}
-
-module.exports = { buildRpm, copyToArtifacts, findRpmbuild };
+module.exports = { buildRpm, findRpmbuild };

--- a/scripts/rpm/make-rpm.js
+++ b/scripts/rpm/make-rpm.js
@@ -16,7 +16,8 @@ const program = require('commander');
 
 const { PROJECT_DIR } = require('../paths');
 const { resolveVersionAndRelease } = require('../packageVersion');
-const { buildRpm, copyToArtifacts, findRpmbuild } = require('./build');
+const { copyToArtifacts } = require('../artifacts');
+const { buildRpm, findRpmbuild } = require('./build');
 const pkgInfo = require('../../package.json');
 const pluginInfo = require('../../src/plugin.json');
 

--- a/scripts/stageDist.js
+++ b/scripts/stageDist.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// Copies the built plugin out of dist/ into a staging directory, applying the shared
+// list of things that never belong in a distributable. The deb and the zip both do
+// this before handing the tree to their packaging tool, and they must agree on what
+// lands in it; the rpm packs its tarball with tar-fs instead but honours the same list.
+
+const fs = require('fs');
+const copy = require('recursive-copy');
+
+const { recursiveCopyFilter } = require('./distContents');
+
+// recursive-copy reports a missing source as an ENOENT on lstat, which surfaced as
+// 'Copy failed: ...' and said nothing about the actual mistake, which is almost always
+// a packaging run against a tree that was never built.
+function assertDistExists(distDir) {
+  if (!fs.existsSync(distDir)) {
+    throw new Error('dist directory not found at ' + distDir + '; run `npm run build` first');
+  }
+}
+
+async function stageDist({ distDir, targetDir, extraExcludes = [] }) {
+  assertDistExists(distDir);
+
+  const results = await copy(distDir, targetDir, {
+    dot: true,
+    junk: false,
+    filter: recursiveCopyFilter(extraExcludes)
+  });
+
+  return results.length;
+}
+
+module.exports = { assertDistExists, stageDist };

--- a/scripts/zip/build.js
+++ b/scripts/zip/build.js
@@ -1,0 +1,77 @@
+'use strict';
+
+// Builds the plugin ZIP: stages dist/ under a directory named for the plugin id and
+// zips that directory. Paths are arguments rather than being read from process.cwd()
+// so the whole pipeline can be exercised against a fixture dist.
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const which = require('which');
+
+const { stageDist } = require('../stageDist');
+
+function findZip() {
+  return which.sync('zip', { nothrow: true });
+}
+
+async function buildZip({ distDir, stagingDir, zipPath, pkgId, verbose = false }) {
+  const log = verbose ? (...args) => console.log(...args) : () => {};
+
+  const zip = findZip();
+
+  if (!zip) {
+    throw new Error('make-zip: zip executable not found on PATH');
+  }
+
+  // stagingDir is ours to own, so start from empty: `zip -r` updates an archive in
+  // place, and a leftover tree from an earlier run would be folded into the new one.
+  fs.rmSync(stagingDir, { recursive: true, force: true });
+
+  try {
+    // Grafana identifies a plugin by the zip's top-level directory name, so the
+    // staged tree has to sit under the plugin id rather than at the archive root.
+    const pluginDir = path.join(stagingDir, pkgId);
+
+    const staged = await stageDist({
+      distDir,
+      targetDir: pluginDir,
+      // Vestigial from when packages were built inside dist; harmless, and cheap
+      // insurance against a stray package directory being shipped.
+      extraExcludes: ['!packages', '!packages/**']
+    });
+
+    log(staged + ' files staged in ' + pluginDir);
+
+    // Same reason: `zip` adds to an existing archive, so a rebuild at the same
+    // version would keep files that are no longer in dist.
+    fs.mkdirSync(path.dirname(zipPath), { recursive: true });
+    fs.rmSync(zipPath, { force: true });
+
+    log('Running zip in ' + stagingDir);
+    const result = spawnSync(zip, ['-r', zipPath, pkgId], {
+      cwd: stagingDir,
+      stdio: verbose ? ['inherit', 'inherit', 'inherit'] : ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf-8'
+    });
+
+    if (result.error) {
+      throw new Error('make-zip: zip could not be run: ' + result.error.message);
+    }
+
+    // spawnSync reports a non-zero exit only in `status`, never in `error`.
+    if (result.status !== 0) {
+      throw new Error(
+        'make-zip: zip exited with status ' + result.status + '\n' + (result.stderr || result.stdout || '')
+      );
+    }
+
+    return { zipPath };
+  } finally {
+    // Not in a `process.exit` path: exit() would skip this and leave a full copy of
+    // dist behind, which the previous script did on every failure.
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  }
+}
+
+module.exports = { buildZip, findZip };

--- a/scripts/zip/make-zip.js
+++ b/scripts/zip/make-zip.js
@@ -1,68 +1,62 @@
 #!/usr/bin/env node
 
-const fs = require('fs-extra');
+// Builds the distributable ZIP of the OpenNMS plugin for Grafana.
+//
+// The work lives in the sibling build module so it can be unit tested; this file only
+// resolves the real paths and package metadata and reports the result.
+//
+// The zip is named with the raw package.json version, unlike the rpm and the deb which
+// split it into version and release. Those two need the split for package sort order; a zip
+// has no such semantics, and keeping the snapshot suffix distinguishes a snapshot build from
+// a release, which a bare version with a release number of 0 would not.
+//
+// Set MAKEZIP_DEBUG=1 for verbose output (zip's own output and the staged file count)
+// when debugging a CI build.
+
+const os = require('os');
 const path = require('path');
-const spawn = require('child_process').spawnSync;
-const copy = require('recursive-copy');
-const rimraf = require('rimraf');
-const which = require('which');
 
-const { recursiveCopyFilter } = require('../distContents');
 const { PROJECT_DIR } = require('../paths');
-const pkginfo = require('../../package.json');
-const plugininfo = require('../../src/plugin.json');
+const { buildZip, findZip } = require('./build');
+const pkgInfo = require('../../package.json');
+const pluginInfo = require('../../src/plugin.json');
 
-try {
-  which.sync('zip');
-} catch (err) {
-  console.log('zip executable not found');
-  process.exit(1);
+const isDebug = process.env.MAKEZIP_DEBUG === '1';
+
+const distDir = path.join(PROJECT_DIR, 'dist');
+const artifactsDir = path.join(PROJECT_DIR, 'artifacts');
+const stagingDir = path.join(os.tmpdir(), 'opennms-grafana-plugin-zip');
+const zipPath = path.join(artifactsDir, pkgInfo.name + '-' + pkgInfo.version + '.zip');
+
+async function main() {
+  if (!findZip()) {
+    console.error('zip executable not found');
+    process.exit(1);
+  }
+
+  console.log(
+    'Building ZIP for ' + pluginInfo.name + ' (' + pluginInfo.id + ') ' + pkgInfo.version
+  );
+
+  try {
+    await buildZip({
+      distDir,
+      stagingDir,
+      zipPath,
+      pkgId: pluginInfo.id,
+      verbose: isDebug
+    });
+  } catch (err) {
+    console.error('ZIP generation failed: ' + err.message);
+    process.exit(1);
+  }
+
+  console.log('Wrote ' + zipPath);
 }
 
-const version = pkginfo.version;
-
-const pkgname = pkginfo.name;
-const pkgid = plugininfo.id;
-const srcdir = path.join(PROJECT_DIR, 'dist');
-const tmpdir = path.join(PROJECT_DIR, 'tmp');
-const workdir = path.join(tmpdir, pkgid);
-const packagedir = path.join(PROJECT_DIR, 'artifacts');
-const zipfile = path.join(packagedir, `${pkgname}-${version}.zip`);
-
-rimraf.sync(workdir);
-rimraf.sync(zipfile);
-fs.mkdirsSync(workdir);
-fs.mkdirsSync(packagedir);
-return copy(path.join(srcdir), workdir, {
-  dot: true,
-  filter: recursiveCopyFilter([
-    '!packages',
-    '!packages/**',
-  ]),
-  junk: false,
-}).then((results) => {
-  console.info(results.length + ' files copied to ' + workdir);
-
-  console.info('* running zip');
-  const ret = spawn('zip', ['-r', zipfile, pkgid], { // NOSONAR
-    cwd: path.join(tmpdir),
-    stdio: ['inherit', 'inherit', 'inherit'],
-  });
-  if (ret.error) {
-    console.log('zip failed: ' + ret.error.message);
-    process.exit(1);
-  }
-
-  // spawnSync reports a non-zero exit only in `status`, never in `error`.
-  if (ret.status !== 0) {
-    console.log('zip exited with status ' + ret.status);
-    process.exit(1);
-  }
-
-  rimraf.sync(tmpdir);
-  console.info('Wrote ' + zipfile);
-  process.exit(0);
-}).catch((error) => {
-  console.log('Copy failed: ' + error);
+// Backstop: anything thrown outside the try above (or from an async rejection)
+// should still report as a build failure rather than an unhandled rejection.
+main().catch((err) => {
+  console.error('ZIP generation failed: ' + err.message);
   process.exit(1);
 });

--- a/src/test/packaging/artifacts.spec.ts
+++ b/src/test/packaging/artifacts.spec.ts
@@ -1,0 +1,39 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { copyToArtifacts } from '../../../scripts/artifacts'
+
+let workDir: string
+
+describe('copyToArtifacts', () => {
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opg-artifacts-test-'))
+  })
+
+  afterEach(() => fs.rmSync(workDir, { recursive: true, force: true }))
+
+  const writePackage = (contents: string) => {
+    const packagePath = path.join(workDir, 'plugin-1.0.0-1.noarch.rpm')
+    fs.writeFileSync(packagePath, contents)
+    return packagePath
+  }
+
+  it('should copy the package into the artifacts directory, creating it if needed', () => {
+    const artifactsDir = path.join(workDir, 'artifacts')
+
+    const target = copyToArtifacts(writePackage('one'), artifactsDir)
+
+    expect(target).toEqual(path.join(artifactsDir, 'plugin-1.0.0-1.noarch.rpm'))
+    expect(fs.readFileSync(target, 'utf-8')).toEqual('one')
+  })
+
+  it('should replace a package left over from an earlier build', () => {
+    const artifactsDir = path.join(workDir, 'artifacts')
+    fs.mkdirSync(artifactsDir)
+    fs.writeFileSync(path.join(artifactsDir, 'plugin-1.0.0-1.noarch.rpm'), 'stale')
+
+    const target = copyToArtifacts(writePackage('fresh'), artifactsDir)
+
+    expect(fs.readFileSync(target, 'utf-8')).toEqual('fresh')
+  })
+})

--- a/src/test/packaging/deb_build.spec.ts
+++ b/src/test/packaging/deb_build.spec.ts
@@ -1,0 +1,186 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { buildDeb, findBuiltDebs, findDpkgBuildpackage, stageDebTree } from '../../../scripts/deb/build'
+
+const pkgInfo = {
+  name: 'opennms-grafana-plugin',
+  description: 'An OpenNMS Integration for Grafana',
+  spec: { requires: ['grafana >= 12.0.0'] }
+}
+
+const pluginInfo = { id: 'opennms-opennms-app' }
+const maintainer = 'OpenNMS Build Account <opennms@opennms.org>'
+
+let workDir: string
+let distDir: string
+let stageDir: string
+
+const writeDistFile = (relativePath: string, contents = 'x') => {
+  const target = path.join(distDir, relativePath)
+  fs.mkdirSync(path.dirname(target), { recursive: true })
+  fs.writeFileSync(target, contents)
+}
+
+/** A dist tree shaped like a real production build, fixtures and all. */
+const setUp = () => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opg-deb-test-'))
+  distDir = path.join(workDir, 'dist')
+  stageDir = path.join(workDir, 'staged')
+  fs.mkdirSync(distDir)
+  writeDistFile('module.js', 'console.log("plugin")')
+  writeDistFile('plugin.json', JSON.stringify({ id: pluginInfo.id }))
+  writeDistFile('img/logo.svg', '<svg/>')
+  writeDistFile('test/react/support/fixtures/helm-v8-dashboard.json', '{}')
+}
+
+const tearDown = () => fs.rmSync(workDir, { recursive: true, force: true })
+
+const stage = (overrides: any = {}) =>
+  stageDebTree({ distDir, workDir: stageDir, pkgInfo, version: '12.0.2', release: '1', maintainer, ...overrides })
+
+const readStaged = (relativePath: string) => fs.readFileSync(path.join(stageDir, relativePath), 'utf-8')
+const stagedExists = (relativePath: string) => fs.existsSync(path.join(stageDir, relativePath))
+
+describe('stageDebTree', () => {
+  beforeEach(setUp)
+  afterEach(tearDown)
+
+  it('should stage the built plugin files', async () => {
+    await stage()
+
+    expect(stagedExists('module.js')).toBe(true)
+    expect(stagedExists('img/logo.svg')).toBe(true)
+  })
+
+  it('should not stage the jest fixtures webpack drags into dist', async () => {
+    await stage()
+
+    expect(stagedExists('test')).toBe(false)
+  })
+
+  it('should copy the debian control files the package needs', async () => {
+    await stage()
+
+    expect(stagedExists('debian/rules')).toBe(true)
+    expect(stagedExists('debian/compat')).toBe(true)
+    expect(stagedExists('debian/source/format')).toBe(true)
+    expect(stagedExists('debian/opennms-grafana-plugin.postinst')).toBe(true)
+  })
+
+  it('should render the templates rather than copying them through', async () => {
+    // A stray control.mustache in debian/ would be packaged as a file, and dpkg would
+    // read the unrendered template as the real control.
+    await stage()
+
+    expect(stagedExists('debian/control.mustache')).toBe(false)
+  })
+
+  it('should write a control naming the maintainer and the grafana dependency', async () => {
+    await stage()
+
+    expect(readStaged('debian/control')).toContain('Maintainer: ' + maintainer)
+    expect(readStaged('debian/control')).toContain('Depends: grafana (>= 12.0.0)')
+  })
+
+  it('should write a changelog for the version and release being built', async () => {
+    await stage()
+
+    expect(readStaged('debian/changelog')).toContain('opennms-grafana-plugin (12.0.2-1)')
+    expect(readStaged('debian/changelog')).toContain('-- ' + maintainer)
+  })
+
+  it('should fail with a message naming the real problem when dist is missing', async () => {
+    fs.rmSync(distDir, { recursive: true })
+
+    await expect(stage()).rejects.toThrow(/npm run build/)
+  })
+})
+
+describe('findBuiltDebs', () => {
+  beforeEach(setUp)
+  afterEach(tearDown)
+
+  it('should find the built deb', () => {
+    fs.writeFileSync(path.join(workDir, 'opennms-grafana-plugin_12.0.2-1_all.deb'), '')
+
+    expect(findBuiltDebs(workDir)).toEqual([path.join(workDir, 'opennms-grafana-plugin_12.0.2-1_all.deb')])
+  })
+
+  it('should ignore the other files dpkg-buildpackage leaves beside it', () => {
+    // dpkg-buildpackage also writes .dsc, .changes, .buildinfo and a source tarball;
+    // only the .deb is the artifact we publish.
+    ;['_12.0.2-1_amd64.changes', '_12.0.2-1_amd64.buildinfo', '_12.0.2-1.dsc', '_12.0.2-1.tar.gz'].forEach(
+      (suffix) => fs.writeFileSync(path.join(workDir, 'opennms-grafana-plugin' + suffix), '')
+    )
+    fs.writeFileSync(path.join(workDir, 'opennms-grafana-plugin_12.0.2-1_all.deb'), '')
+
+    expect(findBuiltDebs(workDir)).toHaveLength(1)
+  })
+
+  it('should return nothing when the directory does not exist', () => {
+    expect(findBuiltDebs(path.join(workDir, 'nope'))).toEqual([])
+  })
+})
+
+const describeDeb = findDpkgBuildpackage() ? describe : describe.skip
+
+if (!findDpkgBuildpackage()) {
+  console.warn('dpkg-buildpackage not found on PATH; skipping the DEB end-to-end tests')
+}
+
+describeDeb('buildDeb', () => {
+  let buildRoot: string
+  let artifactsDir: string
+
+  beforeEach(() => {
+    setUp()
+    buildRoot = path.join(workDir, 'build')
+    artifactsDir = path.join(workDir, 'artifacts')
+  })
+  afterEach(tearDown)
+
+  const build = (overrides: any = {}) =>
+    buildDeb({
+      distDir,
+      buildRoot,
+      artifactsDir,
+      pkgInfo,
+      pluginInfo,
+      version: '12.0.2',
+      release: '1',
+      maintainer,
+      ...overrides
+    })
+
+  it('should publish exactly one deb into the artifacts directory', async () => {
+    const { debPath } = await build()
+
+    expect(debPath).toEqual(path.join(artifactsDir, 'opennms-grafana-plugin_12.0.2-1_all.deb'))
+    expect(fs.existsSync(debPath)).toBe(true)
+  })
+
+  it('should not publish the dsc, changes, buildinfo or source tarball beside it', async () => {
+    // dpkg-buildpackage writes all of those next to the deb. The build used to run
+    // inside artifacts/, so CI stored every one of them as a build artifact.
+    await build()
+
+    expect(fs.readdirSync(artifactsDir)).toEqual(['opennms-grafana-plugin_12.0.2-1_all.deb'])
+  })
+
+  it('should remove its build directory when the build succeeds', async () => {
+    await build()
+
+    expect(fs.existsSync(buildRoot)).toBe(false)
+  })
+
+  it('should remove its build directory when the build fails', async () => {
+    // The old script only cleaned up on the success path, and built inside artifacts/,
+    // so a failed run left a full copy of dist where CI collects build artifacts.
+    fs.rmSync(distDir, { recursive: true })
+
+    await expect(build()).rejects.toThrow()
+
+    expect(fs.existsSync(buildRoot)).toBe(false)
+  })
+})

--- a/src/test/packaging/rpm_build.spec.ts
+++ b/src/test/packaging/rpm_build.spec.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { execFileSync } from 'child_process'
-import { buildRpm, copyToArtifacts, findRpmbuild } from '../../../scripts/rpm/build'
+import { buildRpm, findRpmbuild } from '../../../scripts/rpm/build'
 
 const pkgInfo = {
   name: 'opennms-grafana-plugin',
@@ -180,37 +180,4 @@ describeIfRpmbuild('buildRpm :: build behaviour', () => {
       build({ pkgInfo: { spec: { ...pkgInfo.spec, buildRequires: ['opg-no-such-build-dependency'] } } })
     ).rejects.toThrow(/rpmbuild/i)
   }, 120000)
-})
-
-describe('copyToArtifacts', () => {
-  beforeEach(() => {
-    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opg-artifacts-test-'))
-  })
-
-  afterEach(() => fs.rmSync(workDir, { recursive: true, force: true }))
-
-  const writeRpm = (contents: string) => {
-    const rpmPath = path.join(workDir, 'plugin-1.0.0-1.noarch.rpm')
-    fs.writeFileSync(rpmPath, contents)
-    return rpmPath
-  }
-
-  it('should copy the rpm into the artifacts directory, creating it if needed', () => {
-    const artifactsDir = path.join(workDir, 'artifacts')
-
-    const target = copyToArtifacts(writeRpm('one'), artifactsDir)
-
-    expect(target).toEqual(path.join(artifactsDir, 'plugin-1.0.0-1.noarch.rpm'))
-    expect(fs.readFileSync(target, 'utf-8')).toEqual('one')
-  })
-
-  it('should replace an rpm left over from an earlier build', () => {
-    const artifactsDir = path.join(workDir, 'artifacts')
-    fs.mkdirSync(artifactsDir)
-    fs.writeFileSync(path.join(artifactsDir, 'plugin-1.0.0-1.noarch.rpm'), 'stale')
-
-    const target = copyToArtifacts(writeRpm('fresh'), artifactsDir)
-
-    expect(fs.readFileSync(target, 'utf-8')).toEqual('fresh')
-  })
 })

--- a/src/test/packaging/stage_dist.spec.ts
+++ b/src/test/packaging/stage_dist.spec.ts
@@ -1,0 +1,102 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { assertDistExists, stageDist } from '../../../scripts/stageDist'
+
+let workDir: string
+let distDir: string
+let targetDir: string
+
+const writeDistFile = (relativePath: string, contents = 'x') => {
+  const target = path.join(distDir, relativePath)
+  fs.mkdirSync(path.dirname(target), { recursive: true })
+  fs.writeFileSync(target, contents)
+}
+
+/** A dist tree shaped like a real production build, fixtures and all. */
+const setUp = () => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opg-stage-test-'))
+  distDir = path.join(workDir, 'dist')
+  targetDir = path.join(workDir, 'staged')
+  fs.mkdirSync(distDir)
+  writeDistFile('module.js', 'console.log("plugin")')
+  writeDistFile('plugin.json', '{}')
+  writeDistFile('img/logo.svg', '<svg/>')
+  writeDistFile('test/react/support/fixtures/helm-v8-dashboard.json', '{}')
+}
+
+const tearDown = () => fs.rmSync(workDir, { recursive: true, force: true })
+
+const staged = (relativePath: string) => fs.existsSync(path.join(targetDir, relativePath))
+
+describe('assertDistExists', () => {
+  beforeEach(setUp)
+  afterEach(tearDown)
+
+  it('should tell the caller to build when dist is missing', () => {
+    fs.rmSync(distDir, { recursive: true })
+
+    // The bare recursive-copy failure was an ENOENT on lstat, reported as
+    // 'Copy failed', which says nothing about what to do next.
+    expect(() => assertDistExists(distDir)).toThrow(/npm run build/)
+  })
+
+  it('should accept a dist directory that exists', () => {
+    expect(() => assertDistExists(distDir)).not.toThrow()
+  })
+})
+
+describe('stageDist', () => {
+  beforeEach(setUp)
+  afterEach(tearDown)
+
+  it('should copy the plugin files into the target directory', async () => {
+    await stageDist({ distDir, targetDir })
+
+    expect(staged('module.js')).toBe(true)
+    expect(staged('img/logo.svg')).toBe(true)
+  })
+
+  it('should not stage the jest fixtures webpack drags into dist', async () => {
+    // Excluding only `test/**` still leaves an empty `test` directory behind, so
+    // the directory itself has to go too.
+    await stageDist({ distDir, targetDir })
+
+    expect(staged('test/react/support/fixtures/helm-v8-dashboard.json')).toBe(false)
+    expect(staged('test')).toBe(false)
+  })
+
+  it('should not stage the rpmbuild working directories', async () => {
+    writeDistFile('SOURCES/opennms-grafana-plugin.tar.gz')
+    writeDistFile('SPECS/opennms-grafana-plugin.spec')
+
+    await stageDist({ distDir, targetDir })
+
+    expect(staged('SOURCES')).toBe(false)
+    expect(staged('SPECS')).toBe(false)
+  })
+
+  it('should honour additional excludes from the caller', async () => {
+    writeDistFile('packages/old.deb')
+
+    await stageDist({ distDir, targetDir, extraExcludes: ['!packages', '!packages/**'] })
+
+    expect(staged('packages')).toBe(false)
+    expect(staged('module.js')).toBe(true)
+  })
+
+  it('should report a staged count that leaves out what it filtered', async () => {
+    // The count is what the scripts log. recursive-copy counts directories as
+    // entries too, so this is 3 files plus img/ — the point is that the excluded
+    // fixtures under test/ are not in it.
+    const count = await stageDist({ distDir, targetDir })
+
+    expect(count).toEqual(4)
+  })
+
+  it('should reject rather than stage a partial tree when dist is missing', async () => {
+    fs.rmSync(distDir, { recursive: true })
+
+    await expect(stageDist({ distDir, targetDir })).rejects.toThrow(/npm run build/)
+  })
+})

--- a/src/test/packaging/zip_build.spec.ts
+++ b/src/test/packaging/zip_build.spec.ts
@@ -1,0 +1,121 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { execFileSync } from 'child_process'
+import { buildZip, findZip } from '../../../scripts/zip/build'
+
+const pkgId = 'opennms-opennms-app'
+
+let workDir: string
+let distDir: string
+let stagingDir: string
+let zipPath: string
+
+const writeDistFile = (relativePath: string, contents = 'x') => {
+  const target = path.join(distDir, relativePath)
+  fs.mkdirSync(path.dirname(target), { recursive: true })
+  fs.writeFileSync(target, contents)
+}
+
+/** A dist tree shaped like a real production build, fixtures and all. */
+const setUp = () => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opg-zip-test-'))
+  distDir = path.join(workDir, 'dist')
+  stagingDir = path.join(workDir, 'staging')
+  zipPath = path.join(workDir, 'artifacts', 'opennms-grafana-plugin-12.0.2.zip')
+  fs.mkdirSync(distDir)
+  writeDistFile('module.js', 'console.log("plugin")')
+  writeDistFile('plugin.json', JSON.stringify({ id: pkgId }))
+  writeDistFile('img/logo.svg', '<svg/>')
+  writeDistFile('test/react/support/fixtures/helm-v8-dashboard.json', '{}')
+}
+
+const tearDown = () => fs.rmSync(workDir, { recursive: true, force: true })
+
+const build = (overrides: any = {}) =>
+  buildZip({ distDir, stagingDir, zipPath, pkgId, ...overrides })
+
+/** Entry names inside the built zip, one per line. */
+const entries = () =>
+  execFileSync('unzip', ['-Z1', zipPath], { encoding: 'utf-8' }).trim().split('\n')
+
+describe('findZip', () => {
+  it('should locate the zip executable when it is installed', () => {
+    // Guards the not-found branch: if this returns null on a machine that has zip,
+    // the lookup itself is broken rather than the tool being absent.
+    expect(typeof findZip()).toEqual('string')
+  })
+})
+
+const describeZip = findZip() ? describe : describe.skip
+
+if (!findZip()) {
+  console.warn('zip not found on PATH; skipping the ZIP end-to-end tests')
+}
+
+describeZip('buildZip', () => {
+  beforeEach(setUp)
+  afterEach(tearDown)
+
+  it('should write the zip to the requested path', async () => {
+    await build()
+
+    expect(fs.existsSync(zipPath)).toBe(true)
+  })
+
+  it('should root every entry at the plugin id', async () => {
+    // Grafana loads a plugin zip by its top-level directory; a zip rooted at the
+    // dist contents instead would install to the wrong directory name.
+    await build()
+
+    entries().forEach((entry) => expect(entry.startsWith(pkgId + '/')).toBe(true))
+  })
+
+  it('should include the built plugin files', async () => {
+    await build()
+
+    expect(entries()).toEqual(expect.arrayContaining([`${pkgId}/module.js`, `${pkgId}/img/logo.svg`]))
+  })
+
+  it('should not ship the jest fixtures webpack drags into dist', async () => {
+    await build()
+
+    expect(entries().filter((entry) => entry.includes('/test/'))).toEqual([])
+  })
+
+  it('should replace an existing zip rather than adding to it', async () => {
+    // `zip` updates an archive in place by default, so a rebuild at the same version
+    // would otherwise keep files that are no longer in dist.
+    fs.mkdirSync(path.dirname(zipPath), { recursive: true })
+    fs.writeFileSync(path.join(distDir, 'stale.js'), 'stale')
+    await build()
+    expect(entries()).toContain(`${pkgId}/stale.js`)
+
+    fs.rmSync(path.join(distDir, 'stale.js'))
+    await build()
+
+    expect(entries()).not.toContain(`${pkgId}/stale.js`)
+  })
+
+  it('should remove its staging directory when the build succeeds', async () => {
+    await build()
+
+    expect(fs.existsSync(stagingDir)).toBe(false)
+  })
+
+  it('should remove its staging directory when the build fails', async () => {
+    // The old script only cleaned up on the success path, so a failed run left a
+    // full copy of dist behind.
+    fs.rmSync(distDir, { recursive: true })
+
+    await expect(build()).rejects.toThrow()
+
+    expect(fs.existsSync(stagingDir)).toBe(false)
+  })
+
+  it('should fail with a message naming the real problem when dist is missing', async () => {
+    fs.rmSync(distDir, { recursive: true })
+
+    await expect(build()).rejects.toThrow(/npm run build/)
+  })
+})


### PR DESCRIPTION
Gives `make-deb.js` and `make-zip.js` the treatment `make-rpm.js` got under OPG-527 / PR #1115: a thin entry point over modules that take paths as arguments, so the pipeline can be exercised against a fixture dist.

Bugs the audit found, all now covered by tests:

- Both scripts only cleaned up on the success path, so any failure left a full copy of dist behind. The deb built inside artifacts/ itself, which is where CI collects build artifacts, and the zip staged into a project-root `tmp/` that it then removed wholesale despite not owning it. Both now stage under the system temp directory and clean up in a `finally`.
- `dpkg-buildpackage` writes a `.dsc`, `.changes`, `.buildinfo` and source tarball beside the `.deb`. Building in `artifacts/` meant CI stored all of them; only the `.deb` is signed and published. The deb is now copied out and the rest discarded with the build tree.
- Neither confirmed its artifact existed. The deb never even reported where it went. Both now report the path, and the deb asserts exactly one was built rather than trusting the exit status.
- A trailing `.catch` reported every failure in the chain as "Copy failed", including template and write errors. A missing dist now says to run `npm run build`, the way `make-rpm.js` already did.
- `make-deb.js` mutated the required `package.json` module object with the resolved version and release. Nothing read either field: `renderControl` takes name/description/spec.requires and `renderChangelog` takes version and release as explicit arguments.
- Errors went to `stdout`. They now go to `stderr`, matching `make-rpm.js`.

Adds `MAKEDEB_DEBUG` and `MAKEZIP_DEBUG` to match `MAKERPM_DEBUG`; both scripts were previously unconditionally verbose.

Extracts s`scripts/stageDist.js` (dist staging plus the actionable missing-dist error, shared by deb and zip) and `scripts/artifacts.js` (`copyToArtifacts`, moved out of `scripts/rpm/build.js` now that all three builders publish the same way).

The zip keeps naming its artifact with the raw `package.json` version. The rpm and deb split version from release because their formats need it for sort order; a zip does not, and the suffix distinguishes a snapshot from a release. CI consumes the zip through a glob, so nothing depends on the name.

Verified: full suite (445 pass, 4 skipped), lint, typecheck, build, and real end-to-end builds of all three artifacts.

Note: `.circleci/config.yml` does not run the jest suite at all, so these tests are a local check rather than a CI gate.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-529
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
