### PR TITLE
OPG-517: Link the Alarm Table detail dialog to the OpenNMS alarm page

### DIFF
--- a/docs/modules/datasources/pages/entity_datasource.adoc
+++ b/docs/modules/datasources/pages/entity_datasource.adoc
@@ -10,7 +10,9 @@ For an example of the Entities datasource in use, see <<panel_configuration:dyna
 In addition to the standard HTTP settings, the Entities datasource has an *Additional Options* section with an *OpenNMS Base URL* setting.
 
 Some panels can link directly to a page in the OpenNMS web UI, such as the *Full Details* link in the Alarm Table panel's alarm detail dialog.
-Those links cannot be built from the URL in the HTTP settings: Grafana routes datasource requests through its own proxy, and the configured URL is one the Grafana server must be able to reach, which is not necessarily one your browser can reach.
+
+If the datasource uses the default *Server* (proxy) access mode, those links cannot be built from the URL in the HTTP settings.
+Grafana routes datasource requests through its own proxy, and the configured URL only has to be reachable by the Grafana server, which is not necessarily one your browser can reach.
 A Grafana instance running in Docker, for example, is typically configured with a `host.docker.internal` address.
 
 To enable these links, turn on *Enable OpenNMS Base URL* and enter the base URL of your OpenNMS instance as your browser reaches it, including the context path:
@@ -20,7 +22,13 @@ To enable these links, turn on *Enable OpenNMS Base URL* and enter the base URL 
 http://localhost:8980/opennms
 ----
 
+The URL must start with `http://` or `https://`.
+A value without a scheme, such as `localhost:8980/opennms`, cannot be resolved by the browser and is ignored.
+
 If the setting is turned off, or the URL is left blank, these links are displayed as a path relative to an OpenNMS instance instead of as a working link.
+
+NOTE: If the datasource uses *Browser* (direct) access mode, your browser makes the API calls itself, so the configured URL is already one it can reach and these links work without this setting.
+Turning the setting on still takes precedence, which lets you point the links at a different address than the one used for API calls.
 
 == Datasource queries
 

--- a/docs/modules/datasources/pages/entity_datasource.adoc
+++ b/docs/modules/datasources/pages/entity_datasource.adoc
@@ -25,6 +25,9 @@ http://localhost:8980/opennms
 The URL must start with `http://` or `https://`.
 A value without a scheme, such as `localhost:8980/opennms`, cannot be resolved by the browser and is ignored.
 
+Only the host and path are used.
+Any query string or fragment is discarded, so a URL copied from the address bar of the hash-routed OpenNMS UI, such as `http://localhost:8980/opennms/#/`, works as typed.
+
 If the setting is turned off, or the URL is left blank, these links are displayed as a path relative to an OpenNMS instance instead of as a working link.
 
 NOTE: If the datasource uses *Browser* (direct) access mode, your browser makes the API calls itself, so the configured URL is already one it can reach and these links work without this setting.

--- a/docs/modules/datasources/pages/entity_datasource.adoc
+++ b/docs/modules/datasources/pages/entity_datasource.adoc
@@ -5,6 +5,23 @@
 You can use the Entities datasource to retrieve entity model objects (alarms and nodes) from OpenNMS.
 For an example of the Entities datasource in use, see <<panel_configuration:dynamic-dashboard.adoc#pc-filter-panel, Create a Filter panel>>.
 
+== Datasource configuration
+
+In addition to the standard HTTP settings, the Entities datasource has an *Additional Options* section with an *OpenNMS Base URL* setting.
+
+Some panels can link directly to a page in the OpenNMS web UI, such as the *Full Details* link in the Alarm Table panel's alarm detail dialog.
+Those links cannot be built from the URL in the HTTP settings: Grafana routes datasource requests through its own proxy, and the configured URL is one the Grafana server must be able to reach, which is not necessarily one your browser can reach.
+A Grafana instance running in Docker, for example, is typically configured with a `host.docker.internal` address.
+
+To enable these links, turn on *Enable OpenNMS Base URL* and enter the base URL of your OpenNMS instance as your browser reaches it, including the context path:
+
+[source,]
+----
+http://localhost:8980/opennms
+----
+
+If the setting is turned off, or the URL is left blank, these links are displayed as a path relative to an OpenNMS instance instead of as a working link.
+
 == Datasource queries
 
 This datasource's behavior changes depending on the specified entity.

--- a/src/datasources/entity-ds/EntityConfigEditor.tsx
+++ b/src/datasources/entity-ds/EntityConfigEditor.tsx
@@ -1,12 +1,23 @@
 import React from 'react'
-import { DataSourcePluginOptionsEditorProps } from '@grafana/data'
-import { DataSourceHttpSettings } from '@grafana/ui'
+import { css } from '@emotion/css'
+import { DataSourcePluginOptionsEditorProps, GrafanaTheme2 } from '@grafana/data'
+import { DataSourceHttpSettings, useStyles2 } from '@grafana/ui'
 import { EntityDataSourceOptions } from './types'
+import { OpenNMSBaseUrlConfig } from './OpenNMSBaseUrlConfig'
 import { ClearFilterData } from '../../components/ClearFilterData'
 
 interface Props extends DataSourcePluginOptionsEditorProps<EntityDataSourceOptions> { }
 
+const getStyles = (theme: GrafanaTheme2) => ({
+  spacer: css`
+      margin-top: ${theme.spacing(1.25)};
+      margin-bottom: ${theme.spacing(1.25)};
+  `,
+})
+
 export const EntityConfigEditor: React.FC<Props> = ({ onOptionsChange, options }) => {
+  const s = useStyles2(getStyles)
+
   return (
     <>
       <DataSourceHttpSettings
@@ -14,6 +25,14 @@ export const EntityConfigEditor: React.FC<Props> = ({ onOptionsChange, options }
           dataSourceConfig={options}
           onChange={onOptionsChange}
       />
+
+      <h3 className={s.spacer}>Additional Options</h3>
+
+      <OpenNMSBaseUrlConfig
+        onOptionsChange={onOptionsChange}
+        options={options}
+      />
+
       <ClearFilterData />
     </>
   )

--- a/src/datasources/entity-ds/OpenNMSBaseUrlConfig.tsx
+++ b/src/datasources/entity-ds/OpenNMSBaseUrlConfig.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { DataSourceSettings } from '@grafana/data'
 import { InlineField, InlineSwitch, Input } from '@grafana/ui'
+import { isAbsoluteHttpUrl } from '../../lib/externalLinks'
 import { EntityDataSourceOptions } from './types'
 
 interface Props {
@@ -18,9 +19,15 @@ export const OpenNMSBaseUrlConfig: React.FC<Props> = ({ onOptionsChange, options
   const enabled = options.jsonData.useOpenNMSBaseUrl ?? false
   const baseUrl = options.jsonData.opennmsBaseUrl ?? ''
 
-  // Turning the switch on without entering a url leaves links incomplete, and the placeholder
-  // alone reads like a saved value, so say so here rather than only in the panel.
-  const missingUrl = enabled && !baseUrl.trim()
+  // Turning the switch on without a usable url leaves links incomplete, so say so here rather
+  // than only in the panel. A blank field reads like a saved value because of the placeholder,
+  // and a scheme-less value such as 'localhost:8980/opennms' cannot resolve to OpenNMS at all.
+  const blankUrl = enabled && !baseUrl.trim()
+  const unresolvableUrl = enabled && !blankUrl && !isAbsoluteHttpUrl(baseUrl)
+
+  const error = blankUrl
+    ? 'Enter the base URL of your OpenNMS instance, or turn this setting off.'
+    : 'The base URL must start with http:// or https://, for example http://localhost:8980/opennms.'
 
   const onChange = (jsonData: Partial<EntityDataSourceOptions>) => {
     onOptionsChange({
@@ -67,8 +74,8 @@ export const OpenNMSBaseUrlConfig: React.FC<Props> = ({ onOptionsChange, options
         label='OpenNMS Base URL:'
         tooltip={tooltipText}
         disabled={!enabled}
-        invalid={missingUrl}
-        error='Enter the base URL of your OpenNMS instance, or turn this setting off.'
+        invalid={blankUrl || unresolvableUrl}
+        error={error}
       >
         <Input
           width={40}

--- a/src/datasources/entity-ds/OpenNMSBaseUrlConfig.tsx
+++ b/src/datasources/entity-ds/OpenNMSBaseUrlConfig.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import { DataSourceSettings } from '@grafana/data'
+import { InlineField, InlineSwitch, Input } from '@grafana/ui'
+import { EntityDataSourceOptions } from './types'
+
+interface Props {
+  onOptionsChange: (o: DataSourceSettings<EntityDataSourceOptions>) => void
+  options: DataSourceSettings<EntityDataSourceOptions>
+}
+
+const tooltipText = 'Optionally enter the base URL of your OpenNMS instance as your browser reaches it, ' +
+  'for example http://localhost:8980/opennms. It is used only to build direct links out to OpenNMS pages, ' +
+  'such as the "Full Details" link in the Alarm Table panel\'s alarm detail dialog. This is separate from ' +
+  'the URL in the HTTP settings above, which the Grafana server uses for API calls and which may not be ' +
+  'reachable from your browser - a Docker host.docker.internal address, for instance.'
+
+export const OpenNMSBaseUrlConfig: React.FC<Props> = ({ onOptionsChange, options }) => {
+  const enabled = options.jsonData.useOpenNMSBaseUrl ?? false
+  const baseUrl = options.jsonData.opennmsBaseUrl ?? ''
+
+  // Turning the switch on without entering a url leaves links incomplete, and the placeholder
+  // alone reads like a saved value, so say so here rather than only in the panel.
+  const missingUrl = enabled && !baseUrl.trim()
+
+  const onChange = (jsonData: Partial<EntityDataSourceOptions>) => {
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...options.jsonData,
+        ...jsonData
+      }
+    })
+  }
+
+  return (
+    <>
+      <style>
+        {
+          `
+          .entity-config-editor-switch {
+              display: flex;
+              align-items: center;
+              height: 32px;
+              width: 32px;
+          }
+          .entity-config-editor-switch label {
+              min-width: 32px;
+              width: 32px;
+          }
+          `
+        }
+      </style>
+      <InlineField
+        className='entity-config-editor-switch-field'
+        label='Enable OpenNMS Base URL:'
+        tooltip={tooltipText}
+      >
+        <div className='entity-config-editor-switch'>
+          <InlineSwitch
+            value={enabled}
+            onChange={() => onChange({ useOpenNMSBaseUrl: !enabled })} />
+        </div>
+      </InlineField>
+      {/* InlineField clones its child with its own invalid/disabled/loading props, so 'disabled'
+          has to be set here rather than on the Input, or it gets overwritten with undefined. */}
+      <InlineField
+        label='OpenNMS Base URL:'
+        tooltip={tooltipText}
+        disabled={!enabled}
+        invalid={missingUrl}
+        error='Enter the base URL of your OpenNMS instance, or turn this setting off.'
+      >
+        <Input
+          width={40}
+          placeholder='e.g. http://localhost:8980/opennms'
+          value={baseUrl}
+          onChange={(e) => onChange({ opennmsBaseUrl: e.currentTarget.value })} />
+      </InlineField>
+    </>
+  )
+}

--- a/src/datasources/entity-ds/types.ts
+++ b/src/datasources/entity-ds/types.ts
@@ -17,6 +17,12 @@ import { GrafanaDatasource } from '../../hooks/useDataSources'
  */
 export interface EntityDataSourceOptions extends DataSourceJsonData {
   path?: string;
+
+  /** Whether to use opennmsBaseUrl to build direct links out to OpenNMS. */
+  useOpenNMSBaseUrl?: boolean;
+
+  /** Base URL of the OpenNMS instance as reachable from the user's browser. */
+  opennmsBaseUrl?: string;
 }
 
 export interface EntityQuery extends DataQuery {

--- a/src/lib/client_delegate.ts
+++ b/src/lib/client_delegate.ts
@@ -1,4 +1,5 @@
 import { API, Client, DAO, Model, Rest, GrafanaError } from 'opennms'
+import { OpenNMSLink, resolveOpenNMSLink } from './externalLinks'
 import { isString } from './utils'
 
 export class ClientDelegate {
@@ -9,6 +10,8 @@ export class ClientDelegate {
     timeout?: number
     client: Client
     clientWithMetadata?: Promise<Client>
+    useOpenNMSBaseUrl?: boolean
+    opennmsBaseUrl?: string
 
     constructor(settings: any, public backendSrv: any) {
         this.type = settings.type
@@ -19,6 +22,10 @@ export class ClientDelegate {
         if (settings.jsonData && settings.jsonData.timeout) {
             this.timeout = parseInt(settings.jsonData.timeout,10) * 1000
         }
+
+        // Optional, used only to build links out to a running OpenNMS instance; see getOpenNMSLink
+        this.useOpenNMSBaseUrl = settings.jsonData?.useOpenNMSBaseUrl
+        this.opennmsBaseUrl = settings.jsonData?.opennmsBaseUrl
 
         let authConfig = undefined
 
@@ -38,6 +45,22 @@ export class ClientDelegate {
         this.client = new Client(http)
         this.clientWithMetadata = undefined
      }
+
+    /**
+     * Resolve a url produced by opennms-js, such as Alarm.detailsPage, into a link for display.
+     *
+     * Those urls are built against this datasource's url, which is not reachable from the user's
+     * browser, so they are re-rooted onto the user-configured OpenNMS Base URL when there is one.
+     * Returns a link flagged isAbsolute: false when no base url is configured, and undefined when
+     * there is no url to resolve.
+     */
+    getOpenNMSLink(url?: string): OpenNMSLink | undefined {
+        return resolveOpenNMSLink(url, {
+            datasourceUrl: this.url,
+            baseUrl: this.opennmsBaseUrl,
+            enabled: this.useOpenNMSBaseUrl
+        })
+    }
 
     decorateError(err) {
         let ret = err

--- a/src/lib/externalLinks.ts
+++ b/src/lib/externalLinks.ts
@@ -1,0 +1,67 @@
+/**
+ * Helpers for building links out to a running OpenNMS instance.
+ *
+ * The URL configured in a datasource's HTTP settings is not usable as a link target: in proxy
+ * access mode Grafana rewrites it to '/api/datasources/proxy/uid/<uid>' on the frontend, and in
+ * direct mode it may be an address only the Grafana server can reach (a Docker
+ * 'host.docker.internal' address, for example). opennms-js builds Alarm.detailsPage from that url,
+ * so it has to be re-rooted onto a base URL the user's browser can reach, which the user supplies
+ * separately via the "OpenNMS Base URL" datasource setting.
+ */
+
+export interface OpenNMSLink {
+  href: string
+
+  /** True when href points at a configured OpenNMS instance, false when it is only a relative path. */
+  isAbsolute: boolean
+}
+
+export interface OpenNMSLinkOptions {
+  /** The datasource url as seen by the frontend, used as the prefix to strip. */
+  datasourceUrl?: string
+
+  /** User-configured base URL of the OpenNMS instance, as reachable from the browser. */
+  baseUrl?: string
+
+  /** Whether the user has enabled the OpenNMS Base URL setting. */
+  enabled?: boolean
+}
+
+/** Trim whitespace and any trailing slashes, so a relative path can be appended directly. */
+export const normalizeBaseUrl = (baseUrl: string | undefined): string => {
+  return (baseUrl ?? '').trim().replace(/\/+$/, '')
+}
+
+/**
+ * Reduce a url built against the datasource url to a path relative to an OpenNMS instance,
+ * e.g. '/alarm/detail.htm?id=9849'. The OpenNMS-relative portion comes from opennms-js, so the
+ * page path never needs to be hardcoded here.
+ */
+export const toOpenNMSRelativeUrl = (url: string, datasourceUrl: string | undefined): string => {
+  const prefix = normalizeBaseUrl(datasourceUrl)
+  const relative = prefix && url.startsWith(prefix) ? url.slice(prefix.length) : url
+
+  return relative.startsWith('/') ? relative : `/${relative}`
+}
+
+/**
+ * Resolve a url built against the datasource url into a link for display.
+ *
+ * Returns an absolute link when the user has enabled and entered an OpenNMS Base URL, and
+ * otherwise an OpenNMS-relative one, which callers should not present as clickable.
+ * Returns undefined when there is no url to resolve.
+ */
+export const resolveOpenNMSLink = (url: string | undefined, options: OpenNMSLinkOptions): OpenNMSLink | undefined => {
+  if (!url?.trim()) {
+    return undefined
+  }
+
+  const relative = toOpenNMSRelativeUrl(url.trim(), options.datasourceUrl)
+  const baseUrl = normalizeBaseUrl(options.baseUrl)
+
+  if (options.enabled && baseUrl) {
+    return { href: `${baseUrl}${relative}`, isAbsolute: true }
+  }
+
+  return { href: relative, isAbsolute: false }
+}

--- a/src/lib/externalLinks.ts
+++ b/src/lib/externalLinks.ts
@@ -1,18 +1,24 @@
 /**
  * Helpers for building links out to a running OpenNMS instance.
  *
- * The URL configured in a datasource's HTTP settings is not usable as a link target: in proxy
- * access mode Grafana rewrites it to '/api/datasources/proxy/uid/<uid>' on the frontend, and in
- * direct mode it may be an address only the Grafana server can reach (a Docker
- * 'host.docker.internal' address, for example). opennms-js builds Alarm.detailsPage from that url,
- * so it has to be re-rooted onto a base URL the user's browser can reach, which the user supplies
- * separately via the "OpenNMS Base URL" datasource setting.
+ * opennms-js builds urls such as Alarm.detailsPage from the datasource url, and whether that is
+ * usable as a link target depends on the datasource's access mode:
+ *
+ * - Proxy access: the frontend url is Grafana's own '/api/datasources/proxy/uid/<uid>', and the
+ *   configured url is one only the Grafana server need reach - typically a Docker
+ *   'host.docker.internal' address. Neither reaches OpenNMS from the browser, so such links have
+ *   to be re-rooted onto the base URL the user supplies via the "OpenNMS Base URL" setting.
+ * - Direct (browser) access: the browser makes the API calls itself, so the datasource url is
+ *   already browser-reachable and opennms-js produced a working link. It is left alone.
  */
 
 export interface OpenNMSLink {
   href: string
 
-  /** True when href points at a configured OpenNMS instance, false when it is only a relative path. */
+  /**
+   * True when href resolves to an OpenNMS instance on its own and can be presented as a link.
+   * False when it is only an OpenNMS-relative path, which callers must not make clickable.
+   */
   isAbsolute: boolean
 }
 
@@ -33,15 +39,38 @@ export const normalizeBaseUrl = (baseUrl: string | undefined): string => {
 }
 
 /**
+ * Whether a url is one the browser can resolve on its own.
+ *
+ * A scheme is required: the browser reads 'localhost:8980/opennms' as the unknown scheme
+ * 'localhost:', and 'onms.example.com/opennms' as a path relative to the Grafana page, so
+ * neither reaches OpenNMS. sanitizeUrl passes both through unchanged.
+ */
+export const isAbsoluteHttpUrl = (url: string | undefined): boolean => {
+  return /^https?:\/\//i.test((url ?? '').trim())
+}
+
+/**
  * Reduce a url built against the datasource url to a path relative to an OpenNMS instance,
  * e.g. '/alarm/detail.htm?id=9849'. The OpenNMS-relative portion comes from opennms-js, so the
  * page path never needs to be hardcoded here.
  */
 export const toOpenNMSRelativeUrl = (url: string, datasourceUrl: string | undefined): string => {
   const prefix = normalizeBaseUrl(datasourceUrl)
-  const relative = prefix && url.startsWith(prefix) ? url.slice(prefix.length) : url
 
-  return relative.startsWith('/') ? relative : `/${relative}`
+  if (prefix && url.startsWith(prefix)) {
+    const relative = url.slice(prefix.length)
+
+    return relative.startsWith('/') ? relative : `/${relative}`
+  }
+
+  // The url did not come from this datasource, so there is no prefix of ours to remove. If it
+  // already carries a scheme it stands on its own and must be left alone; prepending '/' would
+  // turn it into '/http://host/...'.
+  if (isAbsoluteHttpUrl(url)) {
+    return url.trim()
+  }
+
+  return url.startsWith('/') ? url : `/${url}`
 }
 
 /**
@@ -52,15 +81,33 @@ export const toOpenNMSRelativeUrl = (url: string, datasourceUrl: string | undefi
  * Returns undefined when there is no url to resolve.
  */
 export const resolveOpenNMSLink = (url: string | undefined, options: OpenNMSLinkOptions): OpenNMSLink | undefined => {
-  if (!url?.trim()) {
+  const trimmed = url?.trim()
+
+  if (!trimmed) {
     return undefined
   }
 
-  const relative = toOpenNMSRelativeUrl(url.trim(), options.datasourceUrl)
+  const relative = toOpenNMSRelativeUrl(trimmed, options.datasourceUrl)
+
+  // A url that could not be reduced to a path did not come from this datasource; it already
+  // resolves on its own, so it is returned as it stands rather than appended to the base url.
+  if (isAbsoluteHttpUrl(relative)) {
+    return { href: relative, isAbsolute: true }
+  }
+
   const baseUrl = normalizeBaseUrl(options.baseUrl)
 
-  if (options.enabled && baseUrl) {
+  // A base url without a scheme cannot resolve, so it is ignored rather than used to build a
+  // link that leads nowhere. The config editor reports it, but a datasource can also be
+  // provisioned from YAML without ever passing through that editor.
+  if (options.enabled && isAbsoluteHttpUrl(baseUrl)) {
     return { href: `${baseUrl}${relative}`, isAbsolute: true }
+  }
+
+  // Direct (browser) access mode: the datasource url is browser-reachable, so opennms-js
+  // already built a working link and there is nothing to re-root.
+  if (isAbsoluteHttpUrl(trimmed)) {
+    return { href: trimmed, isAbsolute: true }
   }
 
   return { href: relative, isAbsolute: false }

--- a/src/lib/externalLinks.ts
+++ b/src/lib/externalLinks.ts
@@ -33,9 +33,25 @@ export interface OpenNMSLinkOptions {
   enabled?: boolean
 }
 
-/** Trim whitespace and any trailing slashes, so a relative path can be appended directly. */
+/**
+ * Reduce a url to the part a path can be appended to: origin and pathname, no trailing slash.
+ *
+ * A query or fragment has to go. The OpenNMS UI is hash-routed, so copying its address out of
+ * the browser yields a trailing '#/', and appending to that gives '/opennms/#/alarm/detail.htm',
+ * which lands on the root with a bogus route. Values that are not parseable as absolute urls -
+ * a relative datasource url used as a prefix to strip, or a base url the user has not finished
+ * typing - keep the plain trailing-slash trim.
+ */
 export const normalizeBaseUrl = (baseUrl: string | undefined): string => {
-  return (baseUrl ?? '').trim().replace(/\/+$/, '')
+  const trimmed = (baseUrl ?? '').trim()
+
+  try {
+    const { origin, pathname } = new URL(trimmed)
+
+    return `${origin}${pathname}`.replace(/\/+$/, '')
+  } catch {
+    return trimmed.replace(/\/+$/, '')
+  }
 }
 
 /**
@@ -49,6 +65,9 @@ export const isAbsoluteHttpUrl = (url: string | undefined): boolean => {
   return /^https?:\/\//i.test((url ?? '').trim())
 }
 
+/** Grafana's own datasource proxy path. No OpenNMS instance serves anything under it. */
+const GRAFANA_PROXY_PATH = /^\/api\/datasources\/proxy\//i
+
 /**
  * Reduce a url built against the datasource url to a path relative to an OpenNMS instance,
  * e.g. '/alarm/detail.htm?id=9849'. The OpenNMS-relative portion comes from opennms-js, so the
@@ -56,11 +75,13 @@ export const isAbsoluteHttpUrl = (url: string | undefined): boolean => {
  */
 export const toOpenNMSRelativeUrl = (url: string, datasourceUrl: string | undefined): string => {
   const prefix = normalizeBaseUrl(datasourceUrl)
+  const relative = prefix && url.startsWith(prefix) ? url.slice(prefix.length) : undefined
 
-  if (prefix && url.startsWith(prefix)) {
-    const relative = url.slice(prefix.length)
-
-    return relative.startsWith('/') ? relative : `/${relative}`
+  // The match has to land on a path boundary. Datasource uids are free text when provisioned,
+  // so one can be a prefix of another: uid 'opennms' against a url from uid 'opennms-entity'
+  // would otherwise leave '-entity/alarm/detail.htm' and build a plausible-looking dead link.
+  if (relative !== undefined && (relative === '' || relative.startsWith('/'))) {
+    return relative === '' ? '/' : relative
   }
 
   // The url did not come from this datasource, so there is no prefix of ours to remove. If it
@@ -93,6 +114,14 @@ export const resolveOpenNMSLink = (url: string | undefined, options: OpenNMSLink
   // resolves on its own, so it is returned as it stands rather than appended to the base url.
   if (isAbsoluteHttpUrl(relative)) {
     return { href: relative, isAbsolute: true }
+  }
+
+  // A leftover proxy path means the url was built against a different datasource than this
+  // client: the panel's datasource was switched while useAlarm still held the cached alarm.
+  // It cannot be mapped onto this instance, and re-rooting it would yield a confident-looking
+  // dead link, so nothing is shown until the next render resolves the new client.
+  if (GRAFANA_PROXY_PATH.test(relative)) {
+    return undefined
   }
 
   const baseUrl = normalizeBaseUrl(options.baseUrl)

--- a/src/panels/alarm-table/AlarmTableControl.tsx
+++ b/src/panels/alarm-table/AlarmTableControl.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { AppEvents, DataFrame, PanelProps } from '@grafana/data'
 import { getAppEvents } from '@grafana/runtime'
-import { ContextMenu, Modal, Pagination, Tab, TabContent, Table, TabsBar, TextLink } from '@grafana/ui'
+import { ContextMenu, Modal, Pagination, Tab, TabContent, Table, TabsBar } from '@grafana/ui'
 import { AlarmTableMenu } from './AlarmTableMenu'
+import { AlarmDetailsLink } from './modal/AlarmDetailsLink'
 import { AlarmTableModalContent } from './modal/AlarmTableModalContent'
 import { AlarmTableSelectionStyles } from './AlarmTableSelectionStyles'
 import { AlarmTableControlProps } from './AlarmTableTypes'
@@ -216,11 +217,7 @@ export const AlarmTableControl: React.FC<PanelProps<AlarmTableControlProps>> = (
                   renderMenuItems={() => <AlarmTableMenu state={alarmControlState} actions={actions} />}
               />}
               <Modal isOpen={detailsModal} title='Alarm Detail' onDismiss={() => setDetailsModal(false)}>
-                  { alarm?.detailsPage &&
-                    <TextLink href={alarm.detailsPage} external={true} style={{ marginBottom: 12, display: 'inline-block' }}>
-                    Full Details
-                    </TextLink>
-                  }
+                  <AlarmDetailsLink alarm={alarm} client={client} />
 
                   <TabsBar>
                       <Tab label='Overview' active={tabActive === 0} onChangeTab={() => tabClick(0)} />

--- a/src/panels/alarm-table/modal/AlarmDetailsLink.tsx
+++ b/src/panels/alarm-table/modal/AlarmDetailsLink.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { css } from '@emotion/css'
+import { GrafanaTheme2 } from '@grafana/data'
+import { TextLink, useStyles2 } from '@grafana/ui'
+import { ClientDelegate } from 'lib/client_delegate'
+import { OnmsAlarm } from 'opennms/src/model'
+
+interface AlarmDetailsLinkProps {
+    alarm: OnmsAlarm | undefined;
+    client: ClientDelegate | undefined;
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+    wrapper: css`
+        margin-bottom: ${theme.spacing(1.5)};
+    `,
+    relativeUrl: css`
+        color: ${theme.colors.text.secondary};
+    `,
+    note: css`
+        color: ${theme.colors.text.secondary};
+        font-size: ${theme.typography.bodySmall.fontSize};
+    `
+})
+
+/**
+ * Link from the alarm detail dialog to the alarm's page in OpenNMS.
+ *
+ * The link can only be completed when the user has configured an OpenNMS Base URL on the Entity
+ * datasource; see ClientDelegate.getOpenNMSLink. Without it we show the OpenNMS-relative url as
+ * plain text rather than as an anchor, because a relative href would resolve against Grafana's own
+ * origin and lead nowhere.
+ */
+export const AlarmDetailsLink: React.FC<AlarmDetailsLinkProps> = ({ alarm, client }) => {
+    const s = useStyles2(getStyles)
+    const link = client?.getOpenNMSLink(alarm?.detailsPage)
+
+    if (!link) {
+        return null
+    }
+
+    if (link.isAbsolute) {
+        return (
+            <div className={s.wrapper}>
+                <TextLink href={link.href} external={true}>Full Details</TextLink>
+            </div>
+        )
+    }
+
+    return (
+        <div className={s.wrapper}>
+            <div>Full Details: <span className={s.relativeUrl}>{link.href}</span></div>
+            <div className={s.note}>
+                Link is relative to an OpenNMS instance. To get a complete link, please go to the
+                Entity Datasource and enter and enable the OpenNMS Base URL field.
+            </div>
+        </div>
+    )
+}

--- a/src/panels/alarm-table/modal/AlarmDetailsLink.tsx
+++ b/src/panels/alarm-table/modal/AlarmDetailsLink.tsx
@@ -51,8 +51,8 @@ export const AlarmDetailsLink: React.FC<AlarmDetailsLinkProps> = ({ alarm, clien
         <div className={s.wrapper}>
             <div>Full Details: <span className={s.relativeUrl}>{link.href}</span></div>
             <div className={s.note}>
-                Link is relative to an OpenNMS instance. To get a complete link, please go to the
-                Entity Datasource and enter and enable the OpenNMS Base URL field.
+                Link is relative to an OpenNMS instance. To get a complete link, go to the Entity
+                Datasource configuration, enable the OpenNMS Base URL setting and enter a URL.
             </div>
         </div>
     )

--- a/src/test/react/alarm_details_link.spec.tsx
+++ b/src/test/react/alarm_details_link.spec.tsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { OnmsAlarm } from 'opennms/src/model'
+import { ClientDelegate } from '../../lib/client_delegate'
+import { AlarmDetailsLink } from '../../panels/alarm-table/modal/AlarmDetailsLink'
+
+const PROXY_URL = '/api/datasources/proxy/uid/af2mze8mmd9moa'
+const RELATIVE_URL = '/alarm/detail.htm?id=9849'
+const NOTE = /Link is relative to an OpenNMS instance/
+
+const clientFor = (jsonData: object) => new ClientDelegate({
+  url: PROXY_URL,
+  type: 'opennms-entity-datasource',
+  name: 'opennms-entity-datasource',
+  jsonData
+}, undefined)
+
+const alarmWith = (detailsPage?: string) => ({ id: 9849, detailsPage } as OnmsAlarm)
+
+describe('AlarmDetailsLink', () => {
+  it('should render a clickable external link when an OpenNMS Base URL is configured', () => {
+    render(
+      <AlarmDetailsLink
+        alarm={alarmWith(`${PROXY_URL}/alarm/detail.htm?id=9849`)}
+        client={clientFor({ useOpenNMSBaseUrl: true, opennmsBaseUrl: 'http://localhost:8980/opennms' })}
+      />
+    )
+
+    const link = screen.getByRole('link', { name: /Full Details/ })
+
+    expect(link).toHaveAttribute('href', 'http://localhost:8980/opennms/alarm/detail.htm?id=9849')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(screen.queryByText(NOTE)).not.toBeInTheDocument()
+  })
+
+  it('should render the relative url as plain text, never a dead link, when no OpenNMS Base URL is configured', () => {
+    render(
+      <AlarmDetailsLink
+        alarm={alarmWith(`${PROXY_URL}/alarm/detail.htm?id=9849`)}
+        client={clientFor({})}
+      />
+    )
+
+    // A relative href would resolve against Grafana's own origin and 404, so there must be no anchor
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.getByText(RELATIVE_URL, { exact: false })).toBeInTheDocument()
+    expect(screen.getByText(NOTE)).toBeInTheDocument()
+  })
+
+  it('should render the relative url as plain text when the base url is enabled but left blank', () => {
+    render(
+      <AlarmDetailsLink
+        alarm={alarmWith(`${PROXY_URL}/alarm/detail.htm?id=9849`)}
+        client={clientFor({ useOpenNMSBaseUrl: true, opennmsBaseUrl: '' })}
+      />
+    )
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.getByText(NOTE)).toBeInTheDocument()
+  })
+
+  it('should render nothing when the alarm has no details page', () => {
+    const { container } = render(
+      <AlarmDetailsLink
+        alarm={alarmWith(undefined)}
+        client={clientFor({ useOpenNMSBaseUrl: true, opennmsBaseUrl: 'http://localhost:8980/opennms' })}
+      />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('should render nothing when there is no alarm or the client has not resolved yet', () => {
+    const withoutAlarm = render(
+      <AlarmDetailsLink
+        alarm={undefined}
+        client={clientFor({ useOpenNMSBaseUrl: true, opennmsBaseUrl: 'http://localhost:8980/opennms' })}
+      />
+    )
+    expect(withoutAlarm.container).toBeEmptyDOMElement()
+
+    // useOpenNMSClient resolves the datasource asynchronously, so client is briefly undefined
+    const withoutClient = render(
+      <AlarmDetailsLink alarm={alarmWith(`${PROXY_URL}/alarm/detail.htm?id=9849`)} client={undefined} />
+    )
+    expect(withoutClient.container).toBeEmptyDOMElement()
+  })
+})

--- a/src/test/react/alarm_details_link.spec.tsx
+++ b/src/test/react/alarm_details_link.spec.tsx
@@ -7,6 +7,8 @@ import { AlarmDetailsLink } from '../../panels/alarm-table/modal/AlarmDetailsLin
 const PROXY_URL = '/api/datasources/proxy/uid/af2mze8mmd9moa'
 const RELATIVE_URL = '/alarm/detail.htm?id=9849'
 const NOTE = /Link is relative to an OpenNMS instance/
+const FULL_NOTE = 'Link is relative to an OpenNMS instance. To get a complete link, go to the Entity '
+  + 'Datasource configuration, enable the OpenNMS Base URL setting and enter a URL.'
 
 const clientFor = (jsonData: object) => new ClientDelegate({
   url: PROXY_URL,
@@ -45,6 +47,17 @@ describe('AlarmDetailsLink', () => {
     expect(screen.queryByRole('link')).not.toBeInTheDocument()
     expect(screen.getByText(RELATIVE_URL, { exact: false })).toBeInTheDocument()
     expect(screen.getByText(NOTE)).toBeInTheDocument()
+  })
+
+  it('should tell the user which setting to turn on and that it needs a url', () => {
+    render(
+      <AlarmDetailsLink
+        alarm={alarmWith(`${PROXY_URL}/alarm/detail.htm?id=9849`)}
+        client={clientFor({})}
+      />
+    )
+
+    expect(screen.getByText(FULL_NOTE)).toBeInTheDocument()
   })
 
   it('should render the relative url as plain text when the base url is enabled but left blank', () => {

--- a/src/test/react/external_links.spec.ts
+++ b/src/test/react/external_links.spec.ts
@@ -25,6 +25,20 @@ describe('ExternalLinks :: normalizeBaseUrl', () => {
     expect(normalizeBaseUrl('  http://localhost:8980/opennms  ')).toEqual('http://localhost:8980/opennms')
   })
 
+  it('should drop a query or fragment, which cannot precede a path', () => {
+    // The OpenNMS UI is hash-routed, so copying the address bar yields a trailing '#/'.
+    // Appending to it gives '.../opennms/#/alarm/detail.htm', which lands on the root.
+    expect(normalizeBaseUrl('http://localhost:8980/opennms/#/')).toEqual('http://localhost:8980/opennms')
+    expect(normalizeBaseUrl('http://localhost:8980/opennms#/alarms')).toEqual('http://localhost:8980/opennms')
+    expect(normalizeBaseUrl('http://localhost:8980/opennms?x=1')).toEqual('http://localhost:8980/opennms')
+    expect(normalizeBaseUrl('http://localhost:8980/opennms/?x=1#/')).toEqual('http://localhost:8980/opennms')
+  })
+
+  it('should leave a relative datasource url alone, since it is used as a prefix to strip', () => {
+    expect(normalizeBaseUrl('/api/datasources/proxy/uid/abc')).toEqual('/api/datasources/proxy/uid/abc')
+    expect(normalizeBaseUrl('/api/datasources/proxy/uid/abc/')).toEqual('/api/datasources/proxy/uid/abc')
+  })
+
   it('should strip trailing slashes so a relative path does not produce a double slash', () => {
     expect(normalizeBaseUrl('http://localhost:8980/opennms/')).toEqual('http://localhost:8980/opennms')
     expect(normalizeBaseUrl('http://localhost:8980/opennms///')).toEqual('http://localhost:8980/opennms')
@@ -75,6 +89,19 @@ describe('ExternalLinks :: toOpenNMSRelativeUrl', () => {
 
   it('should keep the url when there is no datasource url to strip', () => {
     expect(toOpenNMSRelativeUrl('/alarm/detail.htm?id=7', undefined)).toEqual('/alarm/detail.htm?id=7')
+  })
+
+  it('should only strip the datasource url at a path boundary', () => {
+    // A provisioned datasource can set a human-readable uid, so one uid can be a prefix of
+    // another. Matching on the raw string would leave '/-entity/alarm/detail.htm?id=1'.
+    const url = '/api/datasources/proxy/uid/opennms-entity/alarm/detail.htm?id=1'
+
+    expect(toOpenNMSRelativeUrl(url, '/api/datasources/proxy/uid/opennms')).toEqual(url)
+  })
+
+  it('should still strip a datasource url that ends exactly at the path boundary', () => {
+    expect(toOpenNMSRelativeUrl(DETAILS_PAGE, PROXY_URL)).toEqual('/alarm/detail.htm?id=9849')
+    expect(toOpenNMSRelativeUrl(`${PROXY_URL}/alarm/detail.htm`, PROXY_URL)).toEqual('/alarm/detail.htm')
   })
 
   it('should leave an absolute url untouched when it does not match the datasource url', () => {
@@ -171,12 +198,50 @@ describe('ExternalLinks :: resolveOpenNMSLink', () => {
     expect(link).toEqual({ href: 'http://elsewhere.example.com/opennms/alarm/detail.htm?id=9849', isAbsolute: true })
   })
 
+  it('should build a usable link from a base url copied out of the hash-routed OpenNMS UI', () => {
+    const link = resolveOpenNMSLink(DETAILS_PAGE, {
+      datasourceUrl: PROXY_URL,
+      baseUrl: 'http://localhost:8980/opennms/#/',
+      enabled: true
+    })
+
+    expect(link).toEqual({ href: 'http://localhost:8980/opennms/alarm/detail.htm?id=9849', isAbsolute: true })
+  })
+
   it('should ignore a base url with no scheme rather than build a link that leads nowhere', () => {
     for (const baseUrl of ['localhost:8980/opennms', 'onms.example.com/opennms', 'ftp://onms.example.com/opennms']) {
       const link = resolveOpenNMSLink(DETAILS_PAGE, { datasourceUrl: PROXY_URL, baseUrl, enabled: true })
 
       expect(link).toEqual({ href: '/alarm/detail.htm?id=9849', isAbsolute: false })
     }
+  })
+
+  it('should not re-root a stale url still carrying another datasource proxy prefix', () => {
+    // Same datasource-switch window as the absolute case below, but in proxy mode - the mode
+    // this feature exists for - the stale url is relative, so a scheme check alone misses it.
+    const stale = '/api/datasources/proxy/uid/bbbbbbbbbbbbbb/alarm/detail.htm?id=1'
+
+    expect(resolveOpenNMSLink(stale, {
+      datasourceUrl: PROXY_URL,
+      baseUrl: 'http://localhost:8980/opennms',
+      enabled: true
+    })).toBeUndefined()
+  })
+
+  it('should not present a stale proxy url as a relative path when no base url is configured', () => {
+    const stale = '/api/datasources/proxy/uid/bbbbbbbbbbbbbb/alarm/detail.htm?id=1'
+
+    expect(resolveOpenNMSLink(stale, { datasourceUrl: PROXY_URL })).toBeUndefined()
+  })
+
+  it('should still resolve an OpenNMS-relative url that is not a proxy path', () => {
+    const link = resolveOpenNMSLink('/alarm/detail.htm?id=1', {
+      datasourceUrl: PROXY_URL,
+      baseUrl: 'http://localhost:8980/opennms',
+      enabled: true
+    })
+
+    expect(link).toEqual({ href: 'http://localhost:8980/opennms/alarm/detail.htm?id=1', isAbsolute: true })
   })
 
   it('should never concatenate the base url onto an absolute url from another datasource', () => {

--- a/src/test/react/external_links.spec.ts
+++ b/src/test/react/external_links.spec.ts
@@ -1,4 +1,5 @@
 import {
+  isAbsoluteHttpUrl,
   normalizeBaseUrl,
   resolveOpenNMSLink,
   toOpenNMSRelativeUrl
@@ -9,6 +10,9 @@ import { ClientDelegate } from '../../lib/client_delegate'
 // builds Alarm.detailsPage by appending to it. See OnmsServer.resolveURL.
 const PROXY_URL = '/api/datasources/proxy/uid/af2mze8mmd9moa'
 const DETAILS_PAGE = `${PROXY_URL}/alarm/detail.htm?id=9849`
+
+// In direct (browser) access mode Grafana leaves the datasource url as configured
+const DIRECT_URL = 'http://onms.example.com/opennms'
 
 describe('ExternalLinks :: normalizeBaseUrl', () => {
   it('should return an empty string when no base url is given', () => {
@@ -24,6 +28,29 @@ describe('ExternalLinks :: normalizeBaseUrl', () => {
   it('should strip trailing slashes so a relative path does not produce a double slash', () => {
     expect(normalizeBaseUrl('http://localhost:8980/opennms/')).toEqual('http://localhost:8980/opennms')
     expect(normalizeBaseUrl('http://localhost:8980/opennms///')).toEqual('http://localhost:8980/opennms')
+  })
+})
+
+describe('ExternalLinks :: isAbsoluteHttpUrl', () => {
+  it('should accept http and https urls', () => {
+    expect(isAbsoluteHttpUrl('http://localhost:8980/opennms')).toBe(true)
+    expect(isAbsoluteHttpUrl('https://onms.example.com/opennms')).toBe(true)
+    expect(isAbsoluteHttpUrl('  HTTP://localhost:8980/opennms  ')).toBe(true)
+  })
+
+  it('should reject a value with no scheme, which the browser cannot resolve to OpenNMS', () => {
+    // 'localhost:8980/...' parses as the unknown scheme 'localhost:', and
+    // 'onms.example.com/...' as a path relative to the Grafana page
+    expect(isAbsoluteHttpUrl('localhost:8980/opennms')).toBe(false)
+    expect(isAbsoluteHttpUrl('onms.example.com/opennms')).toBe(false)
+    expect(isAbsoluteHttpUrl('/opennms')).toBe(false)
+  })
+
+  it('should reject other schemes', () => {
+    expect(isAbsoluteHttpUrl('ftp://onms.example.com/opennms')).toBe(false)
+    expect(isAbsoluteHttpUrl('javascript:alert(1)')).toBe(false)
+    expect(isAbsoluteHttpUrl(undefined)).toBe(false)
+    expect(isAbsoluteHttpUrl('')).toBe(false)
   })
 })
 
@@ -48,6 +75,16 @@ describe('ExternalLinks :: toOpenNMSRelativeUrl', () => {
 
   it('should keep the url when there is no datasource url to strip', () => {
     expect(toOpenNMSRelativeUrl('/alarm/detail.htm?id=7', undefined)).toEqual('/alarm/detail.htm?id=7')
+  })
+
+  it('should leave an absolute url untouched when it does not match the datasource url', () => {
+    // Reachable while the panel's datasource is switched: useOpenNMSClient resolves the new
+    // client asynchronously while useAlarm still holds the alarm fetched from the old one.
+    // Prepending '/' here would yield '/http://other.example.com/...'.
+    const url = 'http://other.example.com/opennms/alarm/detail.htm?id=1'
+
+    expect(toOpenNMSRelativeUrl(url, PROXY_URL)).toEqual(url)
+    expect(toOpenNMSRelativeUrl(url, undefined)).toEqual(url)
   })
 })
 
@@ -104,6 +141,53 @@ describe('ExternalLinks :: resolveOpenNMSLink', () => {
     const link = resolveOpenNMSLink('alarm/detail.htm?id=7', {})
 
     expect(link).toEqual({ href: '/alarm/detail.htm?id=7', isAbsolute: false })
+  })
+
+  it('should keep a direct-access datasource link absolute when no base url is configured', () => {
+    // In direct (browser) access mode the datasource url is one the browser reaches itself, so
+    // opennms-js already produced a working link. Reducing it to a path would break it.
+    const link = resolveOpenNMSLink(`${DIRECT_URL}/alarm/detail.htm?id=9849`, { datasourceUrl: DIRECT_URL })
+
+    expect(link).toEqual({ href: `${DIRECT_URL}/alarm/detail.htm?id=9849`, isAbsolute: true })
+  })
+
+  it('should keep a direct-access datasource link absolute when the setting is explicitly off', () => {
+    const link = resolveOpenNMSLink(`${DIRECT_URL}/alarm/detail.htm?id=9849`, {
+      datasourceUrl: DIRECT_URL,
+      baseUrl: 'http://elsewhere.example.com/opennms',
+      enabled: false
+    })
+
+    expect(link).toEqual({ href: `${DIRECT_URL}/alarm/detail.htm?id=9849`, isAbsolute: true })
+  })
+
+  it('should let a configured base url re-root a direct-access link', () => {
+    const link = resolveOpenNMSLink(`${DIRECT_URL}/alarm/detail.htm?id=9849`, {
+      datasourceUrl: DIRECT_URL,
+      baseUrl: 'http://elsewhere.example.com/opennms',
+      enabled: true
+    })
+
+    expect(link).toEqual({ href: 'http://elsewhere.example.com/opennms/alarm/detail.htm?id=9849', isAbsolute: true })
+  })
+
+  it('should ignore a base url with no scheme rather than build a link that leads nowhere', () => {
+    for (const baseUrl of ['localhost:8980/opennms', 'onms.example.com/opennms', 'ftp://onms.example.com/opennms']) {
+      const link = resolveOpenNMSLink(DETAILS_PAGE, { datasourceUrl: PROXY_URL, baseUrl, enabled: true })
+
+      expect(link).toEqual({ href: '/alarm/detail.htm?id=9849', isAbsolute: false })
+    }
+  })
+
+  it('should never concatenate the base url onto an absolute url from another datasource', () => {
+    const url = 'http://other.example.com/opennms/alarm/detail.htm?id=1'
+    const link = resolveOpenNMSLink(url, {
+      datasourceUrl: PROXY_URL,
+      baseUrl: 'http://localhost:8980/opennms',
+      enabled: true
+    })
+
+    expect(link).toEqual({ href: url, isAbsolute: true })
   })
 })
 

--- a/src/test/react/external_links.spec.ts
+++ b/src/test/react/external_links.spec.ts
@@ -1,0 +1,156 @@
+import {
+  normalizeBaseUrl,
+  resolveOpenNMSLink,
+  toOpenNMSRelativeUrl
+} from '../../lib/externalLinks'
+import { ClientDelegate } from '../../lib/client_delegate'
+
+// The Grafana frontend rewrites a proxied datasource's url to this shape, and opennms-js
+// builds Alarm.detailsPage by appending to it. See OnmsServer.resolveURL.
+const PROXY_URL = '/api/datasources/proxy/uid/af2mze8mmd9moa'
+const DETAILS_PAGE = `${PROXY_URL}/alarm/detail.htm?id=9849`
+
+describe('ExternalLinks :: normalizeBaseUrl', () => {
+  it('should return an empty string when no base url is given', () => {
+    expect(normalizeBaseUrl(undefined)).toEqual('')
+    expect(normalizeBaseUrl('')).toEqual('')
+    expect(normalizeBaseUrl('   ')).toEqual('')
+  })
+
+  it('should trim surrounding whitespace', () => {
+    expect(normalizeBaseUrl('  http://localhost:8980/opennms  ')).toEqual('http://localhost:8980/opennms')
+  })
+
+  it('should strip trailing slashes so a relative path does not produce a double slash', () => {
+    expect(normalizeBaseUrl('http://localhost:8980/opennms/')).toEqual('http://localhost:8980/opennms')
+    expect(normalizeBaseUrl('http://localhost:8980/opennms///')).toEqual('http://localhost:8980/opennms')
+  })
+})
+
+describe('ExternalLinks :: toOpenNMSRelativeUrl', () => {
+  it('should strip the Grafana datasource proxy prefix', () => {
+    expect(toOpenNMSRelativeUrl(DETAILS_PAGE, PROXY_URL)).toEqual('/alarm/detail.htm?id=9849')
+  })
+
+  it('should strip the datasource url even when it has a trailing slash', () => {
+    expect(toOpenNMSRelativeUrl(DETAILS_PAGE, `${PROXY_URL}/`)).toEqual('/alarm/detail.htm?id=9849')
+  })
+
+  it('should strip an absolute datasource url, as used in direct/browser access mode', () => {
+    const url = 'http://host.docker.internal:8980/opennms/alarm/detail.htm?id=1'
+    expect(toOpenNMSRelativeUrl(url, 'http://host.docker.internal:8980/opennms')).toEqual('/alarm/detail.htm?id=1')
+  })
+
+  it('should keep the url, with a leading slash, when it does not start with the datasource url', () => {
+    expect(toOpenNMSRelativeUrl('alarm/detail.htm?id=7', PROXY_URL)).toEqual('/alarm/detail.htm?id=7')
+    expect(toOpenNMSRelativeUrl('/alarm/detail.htm?id=7', '/some/other/base')).toEqual('/alarm/detail.htm?id=7')
+  })
+
+  it('should keep the url when there is no datasource url to strip', () => {
+    expect(toOpenNMSRelativeUrl('/alarm/detail.htm?id=7', undefined)).toEqual('/alarm/detail.htm?id=7')
+  })
+})
+
+describe('ExternalLinks :: resolveOpenNMSLink', () => {
+  it('should return undefined when there is no url to resolve', () => {
+    const options = { datasourceUrl: PROXY_URL, baseUrl: 'http://localhost:8980/opennms', enabled: true }
+
+    expect(resolveOpenNMSLink(undefined, options)).toBeUndefined()
+    expect(resolveOpenNMSLink('', options)).toBeUndefined()
+    expect(resolveOpenNMSLink('   ', options)).toBeUndefined()
+  })
+
+  it('should build an absolute url when enabled with a base url', () => {
+    const link = resolveOpenNMSLink(DETAILS_PAGE, {
+      datasourceUrl: PROXY_URL,
+      baseUrl: 'http://localhost:8980/opennms',
+      enabled: true
+    })
+
+    expect(link).toEqual({ href: 'http://localhost:8980/opennms/alarm/detail.htm?id=9849', isAbsolute: true })
+  })
+
+  it('should not produce a double slash when the base url has a trailing slash', () => {
+    const link = resolveOpenNMSLink(DETAILS_PAGE, {
+      datasourceUrl: PROXY_URL,
+      baseUrl: 'http://localhost:8980/opennms/',
+      enabled: true
+    })
+
+    expect(link?.href).toEqual('http://localhost:8980/opennms/alarm/detail.htm?id=9849')
+  })
+
+  it('should fall back to the relative url when disabled, even if a base url is saved', () => {
+    const link = resolveOpenNMSLink(DETAILS_PAGE, {
+      datasourceUrl: PROXY_URL,
+      baseUrl: 'http://localhost:8980/opennms',
+      enabled: false
+    })
+
+    expect(link).toEqual({ href: '/alarm/detail.htm?id=9849', isAbsolute: false })
+  })
+
+  it('should fall back to the relative url when enabled but the base url is blank', () => {
+    const link = resolveOpenNMSLink(DETAILS_PAGE, {
+      datasourceUrl: PROXY_URL,
+      baseUrl: '   ',
+      enabled: true
+    })
+
+    expect(link).toEqual({ href: '/alarm/detail.htm?id=9849', isAbsolute: false })
+  })
+
+  it('should pass the url through, with a leading slash, when there is no datasource url to strip', () => {
+    const link = resolveOpenNMSLink('alarm/detail.htm?id=7', {})
+
+    expect(link).toEqual({ href: '/alarm/detail.htm?id=7', isAbsolute: false })
+  })
+})
+
+describe('ClientDelegate :: getOpenNMSLink', () => {
+  const settingsFor = (jsonData: object) => ({
+    url: PROXY_URL,
+    type: 'opennms-entity-datasource',
+    name: 'opennms-entity-datasource',
+    jsonData
+  })
+
+  it('should build an absolute link when the OpenNMS Base URL is enabled', () => {
+    const client = new ClientDelegate(settingsFor({
+      useOpenNMSBaseUrl: true,
+      opennmsBaseUrl: 'http://localhost:8980/opennms'
+    }), undefined)
+
+    expect(client.getOpenNMSLink(DETAILS_PAGE)).toEqual({
+      href: 'http://localhost:8980/opennms/alarm/detail.htm?id=9849',
+      isAbsolute: true
+    })
+  })
+
+  it('should build a relative link when the OpenNMS Base URL is not enabled', () => {
+    const client = new ClientDelegate(settingsFor({
+      useOpenNMSBaseUrl: false,
+      opennmsBaseUrl: 'http://localhost:8980/opennms'
+    }), undefined)
+
+    expect(client.getOpenNMSLink(DETAILS_PAGE)).toEqual({
+      href: '/alarm/detail.htm?id=9849',
+      isAbsolute: false
+    })
+  })
+
+  it('should build a relative link for a datasource saved before this setting existed', () => {
+    const client = new ClientDelegate(settingsFor({}), undefined)
+
+    expect(client.getOpenNMSLink(DETAILS_PAGE)).toEqual({
+      href: '/alarm/detail.htm?id=9849',
+      isAbsolute: false
+    })
+  })
+
+  it('should return undefined when the alarm has no details page', () => {
+    const client = new ClientDelegate(settingsFor({ useOpenNMSBaseUrl: true, opennmsBaseUrl: 'http://x/opennms' }), undefined)
+
+    expect(client.getOpenNMSLink(undefined)).toBeUndefined()
+  })
+})

--- a/src/test/react/opennms_base_url_config.spec.tsx
+++ b/src/test/react/opennms_base_url_config.spec.tsx
@@ -1,0 +1,107 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { DataSourceSettings } from '@grafana/data'
+import { EntityDataSourceOptions } from '../../datasources/entity-ds/types'
+import { OpenNMSBaseUrlConfig } from '../../datasources/entity-ds/OpenNMSBaseUrlConfig'
+
+const settingsWith = (jsonData: object) =>
+  ({ jsonData: { path: 'keep-me', ...jsonData } } as DataSourceSettings<EntityDataSourceOptions>)
+
+describe('OpenNMSBaseUrlConfig', () => {
+  it('should show the setting as off, with the url disabled, for a datasource that has never used it', () => {
+    render(<OpenNMSBaseUrlConfig options={settingsWith({})} onOptionsChange={jest.fn()} />)
+
+    expect(screen.getByRole('switch')).not.toBeChecked()
+    expect(screen.getByRole('textbox')).toBeDisabled()
+  })
+
+  it('should enable the url input once the setting is switched on', () => {
+    render(<OpenNMSBaseUrlConfig options={settingsWith({ useOpenNMSBaseUrl: true })} onOptionsChange={jest.fn()} />)
+
+    expect(screen.getByRole('switch')).toBeChecked()
+    expect(screen.getByRole('textbox')).toBeEnabled()
+  })
+
+  it('should turn the setting on without discarding other jsonData', () => {
+    const onOptionsChange = jest.fn()
+    render(<OpenNMSBaseUrlConfig options={settingsWith({})} onOptionsChange={onOptionsChange} />)
+
+    fireEvent.click(screen.getByRole('switch'))
+
+    expect(onOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({ jsonData: { path: 'keep-me', useOpenNMSBaseUrl: true } })
+    )
+  })
+
+  it('should turn the setting back off, keeping the saved url', () => {
+    const onOptionsChange = jest.fn()
+    const options = settingsWith({ useOpenNMSBaseUrl: true, opennmsBaseUrl: 'http://localhost:8980/opennms' })
+    render(<OpenNMSBaseUrlConfig options={options} onOptionsChange={onOptionsChange} />)
+
+    fireEvent.click(screen.getByRole('switch'))
+
+    expect(onOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: {
+          path: 'keep-me',
+          useOpenNMSBaseUrl: false,
+          opennmsBaseUrl: 'http://localhost:8980/opennms'
+        }
+      })
+    )
+  })
+
+  it('should save the url as entered', () => {
+    const onOptionsChange = jest.fn()
+    render(
+      <OpenNMSBaseUrlConfig options={settingsWith({ useOpenNMSBaseUrl: true })} onOptionsChange={onOptionsChange} />
+    )
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'http://localhost:8980/opennms' } })
+
+    expect(onOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: {
+          path: 'keep-me',
+          useOpenNMSBaseUrl: true,
+          opennmsBaseUrl: 'http://localhost:8980/opennms'
+        }
+      })
+    )
+  })
+  it('should ask for a url when the setting is switched on but the url is blank', () => {
+    render(<OpenNMSBaseUrlConfig options={settingsWith({ useOpenNMSBaseUrl: true })} onOptionsChange={jest.fn()} />)
+
+    expect(screen.getByText(/Enter the base URL of your OpenNMS instance/)).toBeInTheDocument()
+  })
+
+  it('should stop asking for a url once one is entered', () => {
+    const options = settingsWith({ useOpenNMSBaseUrl: true, opennmsBaseUrl: 'http://localhost:8980/opennms' })
+    render(<OpenNMSBaseUrlConfig options={options} onOptionsChange={jest.fn()} />)
+
+    expect(screen.queryByText(/Enter the base URL of your OpenNMS instance/)).not.toBeInTheDocument()
+  })
+
+  it('should treat a blank url as valid while the setting is switched off', () => {
+    render(<OpenNMSBaseUrlConfig options={settingsWith({})} onOptionsChange={jest.fn()} />)
+
+    expect(screen.queryByText(/Enter the base URL of your OpenNMS instance/)).not.toBeInTheDocument()
+  })
+
+  it('should ask for a url when the entered value is only whitespace', () => {
+    render(
+      <OpenNMSBaseUrlConfig
+        options={settingsWith({ useOpenNMSBaseUrl: true, opennmsBaseUrl: '   ' })}
+        onOptionsChange={jest.fn()}
+      />
+    )
+
+    expect(screen.getByText(/Enter the base URL of your OpenNMS instance/)).toBeInTheDocument()
+  })
+
+  it('should mark the placeholder as an example so it is not mistaken for a saved value', () => {
+    render(<OpenNMSBaseUrlConfig options={settingsWith({ useOpenNMSBaseUrl: true })} onOptionsChange={jest.fn()} />)
+
+    expect(screen.getByPlaceholderText(/^e\.g\. /)).toBeInTheDocument()
+  })
+})

--- a/src/test/react/opennms_base_url_config.spec.tsx
+++ b/src/test/react/opennms_base_url_config.spec.tsx
@@ -99,6 +99,46 @@ describe('OpenNMSBaseUrlConfig', () => {
     expect(screen.getByText(/Enter the base URL of your OpenNMS instance/)).toBeInTheDocument()
   })
 
+  it('should reject a url with no scheme, which the browser cannot resolve to OpenNMS', () => {
+    for (const opennmsBaseUrl of ['localhost:8980/opennms', 'onms.example.com/opennms', 'ftp://onms.example.com']) {
+      const { unmount } = render(
+        <OpenNMSBaseUrlConfig
+          options={settingsWith({ useOpenNMSBaseUrl: true, opennmsBaseUrl })}
+          onOptionsChange={jest.fn()}
+        />
+      )
+
+      expect(screen.getByText(/must start with http:\/\/ or https:\/\//)).toBeInTheDocument()
+      unmount()
+    }
+  })
+
+  it('should accept a full http or https url without complaint', () => {
+    for (const opennmsBaseUrl of ['http://localhost:8980/opennms', 'https://onms.example.com/opennms']) {
+      const { unmount } = render(
+        <OpenNMSBaseUrlConfig
+          options={settingsWith({ useOpenNMSBaseUrl: true, opennmsBaseUrl })}
+          onOptionsChange={jest.fn()}
+        />
+      )
+
+      expect(screen.queryByText(/Enter the base URL of your OpenNMS instance/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/must start with http:\/\/ or https:\/\//)).not.toBeInTheDocument()
+      unmount()
+    }
+  })
+
+  it('should not complain about a saved url while the setting is switched off', () => {
+    render(
+      <OpenNMSBaseUrlConfig
+        options={settingsWith({ opennmsBaseUrl: 'localhost:8980/opennms' })}
+        onOptionsChange={jest.fn()}
+      />
+    )
+
+    expect(screen.queryByText(/must start with http:\/\/ or https:\/\//)).not.toBeInTheDocument()
+  })
+
   it('should mark the placeholder as an example so it is not mistaken for a saved value', () => {
     render(<OpenNMSBaseUrlConfig options={settingsWith({ useOpenNMSBaseUrl: true })} onOptionsChange={jest.fn()} />)
 


### PR DESCRIPTION
The "Full Details" link in the Alarm Table panel's alarm detail dialog never worked.

`opennms-js` builds `Alarm.detailsPage` from the datasource url, which is Grafana's proxy path ('/api/datasources/proxy/uid/<uid>'), so the link pointed back at Grafana rather than at OpenNMS. The url in the HTTP settings is no help either: it is one the Grafana server must reach, and is typically a Docker `host.docker.internal` address that a browser cannot reach.

Adds an optional "OpenNMS Base URL" setting to the Entity datasource, which is the base url of an OpenNMS instance as the user's browser reaches it, and used that as the base for links. The OpenNMS-relative portion is recovered by stripping the datasource url prefix, so the alarm page path stays owned by `opennms-js`.

Grafana permits this: `TextLink`'s external branch emits a plain anchor and deliberately skips `locationUtil.stripBaseFromUrl`, `textUtil.sanitizeUrl` leaves absolute http(s) urls untouched, and the plugin validator's link analyzers (`safelinks`, `brokenlinks`) only cover `plugin.json` and documentation urls.

If no base url is configured, the link is shown as an OpenNMS-relative path in plain text, not as a link, since a relative href would resolve against Grafana's own origin and lead nowhere. Enabling the setting without entering a url marks the field invalid rather than silently degrading to that state.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-517
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
