### PR TITLE
OPG-500: move ci to newer base images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,10 +331,11 @@ jobs:
       - run:
           name: Install RPM build tooling
           command: |
-            # tar is needed by the spec's %setup and ships in neither the base image
-            # nor rpm-build's dependencies. rpm-sign comes from the orb step below.
+            # Rocky 9 carries no node; rpm-sign comes from the orb step below. tar,
+            # which the spec's %setup shells out to, is in the base image and is a
+            # declared dependency of rpm-build, so it does not need listing here.
             dnf -y module enable nodejs:22
-            dnf -y --setopt=install_weak_deps=False install nodejs npm rpm-build tar
+            dnf -y --setopt=install_weak_deps=False install nodejs npm rpm-build
       - sign-packages/install-rpm-dependencies:
           skip_if_forked_pr: true
       - sign-packages/setup-env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,21 +2,24 @@ version: 2.1
 
 executors:
 
-  build-executor-centos:
+  # Builds the RPM. opennms/build-env has no current RHEL-family tag -- the last one
+  # was CentOS 8 with Node 16, both long EOL -- so this tracks Rocky Linux 9 and
+  # installs the build tooling in the job. Nothing here needs a JDK.
+  rpm-build-executor:
     docker:
-      - image: opennms/build-env:11.0.14_9-3.8.7-b9528
+      - image: rockylinux/rockylinux:9
 
-  build-executor-debian:
+  # Builds the DEB. The old opennms/build-env:debian-jdk11 tag was Debian 11
+  # (bullseye) with Node 18, which is older than this plugin's engines range
+  # (>=22 <25). The official Node image on Debian 13 (trixie) gives us Node 22 and
+  # dpkg out of the box; debhelper is installed in the job.
+  deb-build-executor:
     docker:
-      - image: opennms/build-env:debian-jdk11-b10453
+      - image: node:22-trixie
 
   node-executor:
     docker:
-      - image: cimg/node:22.22
-
-  docs-executor:
-    docker:
-      - image: opennms/antora:3.1.4-b10433
+      - image: cimg/node:22.23.2
 
 orbs:
   cloudsmith: cloudsmith/cloudsmith@1.0.4
@@ -174,18 +177,26 @@ jobs:
             - project
 
   build-docs:
-    executor: docs-executor
+    # Antora comes from this repo's own @antora devDependencies, not from an image.
+    # opennms/antora is Alpine 3.18 on Node 16 in every tag, newest included, and
+    # Antora 3.2 requires Node >= 20, so that image can no longer run it at all: the
+    # CLI resolves @antora/site-generator from the playbook directory, loaded the
+    # repo's copy, and died in its pino dependency.
+    executor: node-executor
     steps:
       - attach_workspace:
           at: ~/
       - run:
           name: Validate Xrefs in docs
           command: |
-            NODE_PATH="$(npm -g root)" antora --generator @antora/xref-validator local-site.yml
+            # validate-xrefs installs @antora/xref-validator itself: it is not on
+            # npmjs.org, only a GitLab tarball, so it cannot be a devDependency. The
+            # pinned commit lives in package.json so CI and a local run stay identical.
+            npm run validate-xrefs
       - run:
           name: Generate HTML output for documentation
           command: |
-            NODE_PATH="$(npm -g root)" antora --stacktrace generate local-site.yml
+            npm run docs
       - store_artifacts:
           path: build/site.zip
           destination: site.zip
@@ -231,7 +242,7 @@ jobs:
             fi
 
   make-tarball:
-    executor: build-executor-centos
+    executor: node-executor
     resource_class: small
     steps:
       - attach_workspace:
@@ -253,7 +264,7 @@ jobs:
             - ./project/version.tag
 
   make-zip:
-    executor: build-executor-centos
+    executor: node-executor
     resource_class: small
     steps:
       - attach_workspace:
@@ -300,17 +311,18 @@ jobs:
           paths:
             - ./project/artifacts
   make-rpm:
-    executor: build-executor-centos
+    executor: rpm-build-executor
     resource_class: small
     steps:
       - attach_workspace:
           at: ~/
       - run:
-          name: Update Repo list
+          name: Install RPM build tooling
           command: |
-            sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-*.repo
-            sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo
-            sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/CentOS-*.repo
+            # tar is needed by the spec's %setup and ships in neither the base image
+            # nor rpm-build's dependencies. rpm-sign comes from the orb step below.
+            dnf -y module enable nodejs:22
+            dnf -y --setopt=install_weak_deps=False install nodejs npm rpm-build tar
       - sign-packages/install-rpm-dependencies:
           skip_if_forked_pr: true
       - sign-packages/setup-env:
@@ -335,11 +347,22 @@ jobs:
             - ./project/artifacts
 
   make-deb:
-    executor: build-executor-debian
+    executor: deb-build-executor
     resource_class: small
     steps:
       - attach_workspace:
           at: ~/
+      - run:
+          name: Install DEB build tooling
+          command: |
+            # This apt-get update is also what makes the orb step below work. Debian 13
+            # ships its sources as deb822 in /etc/apt/sources.list.d/debian.sources and
+            # has no /etc/apt/sources.list at all, and the orb pins
+            # -o Dir::Etc::sourcelist=sources.list -o Dir::Etc::sourceparts=- so on its
+            # own it refreshes nothing and cannot find gnupg2 or debsigs. It passes
+            # -o APT::Get::List-Cleanup=0, so the lists this leaves behind survive.
+            apt-get update
+            apt-get -y --no-install-recommends install build-essential debhelper fakeroot
       - sign-packages/install-deb-dependencies:
           skip_if_forked_pr: true
       - sign-packages/setup-env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,12 @@ jobs:
           name: Generate HTML output for documentation
           command: |
             npm run docs
+      - run:
+          name: Validate anchors in the generated docs
+          command: |
+            # Antora validates the page half of an xref target and never the #anchor
+            # half, so this reads the site npm run docs just built and has to follow it.
+            npm run validate-anchors
       - store_artifacts:
           path: build/site.zip
           destination: site.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,6 +186,12 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      # Antora is a devDependency now, and this job requires only pre-build, which
+      # checks out but never installs. The old opennms/antora image carried Antora
+      # globally so the workspace contents did not matter; using this repo's own copy
+      # means they do. Installing here rather than adding `requires: build` keeps the
+      # docs building in parallel with the plugin instead of queueing behind it.
+      - install-node-dependencies
       - run:
           name: Validate Xrefs in docs
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ conf/custom.ini
 
 # Antora documentation
 public/
+# xref validator, installed on demand by `npm run validate-xrefs`
+.antora-tools/
 build/
 
 # Not ready yet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,50 @@ A full reinstall also re-resolves every `^` range, so it can surface breakage un
 - `MAKERPM_DEBUG=1` / `MAKEDEB_DEBUG=1` / `MAKEZIP_DEBUG=1` turn on verbose output for
   CircleCI debugging. Each entry point is a thin wrapper; the work lives in a sibling
   `build.js` that takes paths as arguments so it can be tested against a fixture `dist`
+- CI executors: `make-rpm` runs on `rockylinux/rockylinux:9` and `make-deb` on
+  `node:22-trixie`; `make-tarball`/`make-zip` need only node, `tar` and `zip` and run on
+  `node-executor`. `opennms/build-env` is **not** an option any more — its newest
+  RHEL-family tag is CentOS 8 with Node 16 and its newest Debian tag is bullseye with
+  Node 18, both far below this repo's `engines` (`>=22 <25`). Neither image carries a
+  JDK, because nothing in this pipeline uses Java
+- `sign-packages/install-deb-dependencies` pins
+  `-o Dir::Etc::sourcelist=sources.list -o Dir::Etc::sourceparts=-`, and Debian 12+ ships
+  its sources as deb822 in `/etc/apt/sources.list.d/debian.sources` with no
+  `/etc/apt/sources.list` at all. On its own the orb step therefore refreshes nothing and
+  fails with "Unable to locate package debsigs". `make-deb` runs a plain `apt-get update`
+  first (it needs `debhelper` anyway); the orb passes `-o APT::Get::List-Cleanup=0`, so
+  those lists survive into its own call. Do not drop that step
+- `build-docs` runs on `node-executor` and takes Antora from this repo's own `@antora`
+  devDependencies. There is deliberately no `docs-executor`: every `opennms/antora` tag,
+  newest included, is Alpine 3.18 on **Node 16**, and Antora 3.2 requires Node >= 20, so
+  that image cannot run current Antora at all. Do **not** reintroduce it. The symptom it
+  produced was `diagChan.tracingChannel is not a function` out of `pino` — the CLI
+  resolves `@antora/site-generator` from the playbook directory first, so the image's
+  Node 16 loaded the repo's own copy and died in its `pino@10` (Node >= 20) dependency.
+  Both the image bundle and the repo tree must therefore stay on the same Node
+- `@antora/xref-validator` is **not** on npmjs.org — only a GitLab tarball — so it cannot
+  be a devDependency. `npm run validate-xrefs` installs it itself, into `.antora-tools/`
+  (gitignored) and pinned to a commit rather than `main`, which has not moved since 2022.
+  `build-docs` just calls that script, so the pinned commit lives in exactly one place.
+  Two flags in it are load-bearing:
+  - `--omit=optional`: the validator declares `@antora/*` as `optionalDependencies` on a
+    floating `^3.0.0-alpha.1` range, so installing them gives it a second Antora that can
+    drift from the lockfile's. Omitted, its bare `require`s fall through to
+    `./node_modules` and it validates with the same Antora that `npm run docs` generates
+    with. Verified via `require.resolve`, not assumed
+  - `--log-failure-level=error`: Antora's default `failure_level` is **`fatal`**, so a
+    broken xref logs at `error` and still exits **0**. Without this the step reports
+    problems and passes anyway. `npm run docs` has the same default and is deliberately
+    left alone, so authoring locally is not blocked; `validate-xrefs` is the gate
+- The docs UI bundle comes from `OpenNMS/antora-ui-opennms` (v3.1.1), matching
+  `antora-playbook-local.yml` in the main OpenNMS repo. The old
+  `opennms-forge/antora-ui-opennms` bundle is a different repo whose newest release is
+  v3.1.0 from 2022. The bundle is only presentation assets — it has no bearing on the
+  Node/Antora version problem above
+- Rocky 9 ships neither `tar` nor `nodejs` and `rpm-build` does not pull `tar` in, so
+  `make-rpm` installs `nodejs npm rpm-build tar` explicitly — the spec's `%setup` needs
+  `tar`. The orb's `.rpmmacros` forces a bzip2 payload (`w0.bzdio`), which keeps the RPM
+  installable on older rpm than el9's zstd default would
 - The deb builds under the system temp directory, never under `artifacts/`.
   `dpkg-buildpackage` writes a `.dsc`, `.changes`, `.buildinfo` and source tarball beside the
   `.deb`, and only the `.deb` is signed and published; building in `artifacts/` shipped all of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,9 +197,19 @@ A full reinstall also re-resolves every `^` range, so it can surface breakage un
   cross-page link; a static "is this anchor on this page" check flags those as broken and
   is wrong. What is actually broken is a bare `<<anchor>>` naming an anchor on a
   *different* page: it renders as `href="#anchor"` and goes nowhere. Prefer
-  `xref:module:page.adoc#anchor[text]` for anything cross-page. Antora validates the
-  page half of an xref target, never the `#anchor` half, so a wrong anchor with a right
-  page is still silent
+  `xref:module:page.adoc#anchor[text]` for anything cross-page
+- Antora validates the page half of an xref target and **never** the `#anchor` half, so
+  `xref:installation:upgrading.adoc#typo[]` resolves the page, renders a link to nowhere
+  and reports nothing at any log level. `scripts/docs/validateAnchors.js` covers that,
+  and `build-docs` runs it as a third step because it reads the site `npm run docs`
+  builds. It works on the **generated HTML**, not the AsciiDoc source, and deliberately
+  so: anchors come from auto-generated section ids (subject to `idprefix`/`idseparator`),
+  `[[x]]`, `[#x]`, block ids and discrete headings, so deriving them from source means
+  reimplementing Asciidoctor — which reports good links as broken. The rendered `id`
+  attributes are ground truth. It checks whole pages rather than scoping to `<article>`,
+  which would couple it to the UI bundle's markup and silently check nothing if a future
+  bundle renamed that element; every fragment link outside `<article>` in this site is a
+  bare `href="#"` navbar toggle, which is skipped anyway
 - The docs UI bundle comes from `OpenNMS/antora-ui-opennms` (v3.1.1), matching
   `antora-playbook-local.yml` in the main OpenNMS repo. The old
   `opennms-forge/antora-ui-opennms` bundle is a different repo whose newest release is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,8 @@ A full reinstall also re-resolves every `^` range, so it can surface breakage un
   be a devDependency. `npm run validate-xrefs` installs it itself, into `.antora-tools/`
   (gitignored) and pinned to a commit rather than `main`, which has not moved since 2022.
   `build-docs` just calls that script, so the pinned commit lives in exactly one place.
-  Two flags in it are load-bearing:
+  Two flags in it are load-bearing — `--omit=optional`, and the
+  `--log-failure-level=warn` covered under strictness below:
   - `--omit=optional`: the validator declares `@antora/*` as `optionalDependencies` on a
     floating `^3.0.0-alpha.1` range, so installing them gives it a second Antora that can
     drift from the lockfile's. Omitted, its bare `require`s fall through to
@@ -220,10 +221,14 @@ A full reinstall also re-resolves every `^` range, so it can surface breakage un
   `opennms-forge/antora-ui-opennms` bundle is a different repo whose newest release is
   v3.1.0 from 2022. The bundle is only presentation assets — it has no bearing on the
   Node/Antora version problem above
-- Rocky 9 ships neither `tar` nor `nodejs` and `rpm-build` does not pull `tar` in, so
-  `make-rpm` installs `nodejs npm rpm-build tar` explicitly — the spec's `%setup` needs
-  `tar`. The orb's `.rpmmacros` forces a bzip2 payload (`w0.bzdio`), which keeps the RPM
-  installable on older rpm than el9's zstd default would
+- Rocky 9 carries no `nodejs`, so `make-rpm` installs `nodejs npm rpm-build` explicitly
+  (`rpm-sign` comes from the signing orb). `tar`, which the spec's `%setup` shells out
+  to, needs no listing: it is in the base image *and* a declared dependency of
+  `rpm-build`. An earlier version of this note claimed the opposite, because the probe
+  used `which` — which Rocky 9 does **not** ship — so `which tar` failed and read as a
+  missing tar. Probe for binaries with `command -v`, never `which`. The orb's
+  `.rpmmacros` forces a bzip2 payload (`w0.bzdio`), which keeps the RPM installable on
+  older rpm than el9's zstd default would
 - The deb builds under the system temp directory, never under `artifacts/`.
   `dpkg-buildpackage` writes a `.dsc`, `.changes`, `.buildinfo` and source tarball beside the
   `.deb`, and only the `.deb` is signed and published; building in `artifacts/` shipped all of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,10 +176,30 @@ A full reinstall also re-resolves every `^` range, so it can surface breakage un
     drift from the lockfile's. Omitted, its bare `require`s fall through to
     `./node_modules` and it validates with the same Antora that `npm run docs` generates
     with. Verified via `require.resolve`, not assumed
-  - `--log-failure-level=error`: Antora's default `failure_level` is **`fatal`**, so a
-    broken xref logs at `error` and still exits **0**. Without this the step reports
-    problems and passes anyway. `npm run docs` has the same default and is deliberately
-    left alone, so authoring locally is not blocked; `validate-xrefs` is the gate
+  Xref validation is **strict**, and getting there took two steps because
+  `--log-failure-level` alone cannot express it:
+  - Antora's default `failure_level` is **`fatal`**, so even a `target of xref not
+    found` (logged at `error`) exited **0**. Both `validate-xrefs` and `docs` now pass
+    `--log-failure-level=warn`, which covers warn and above — including missing images
+    and includes, not just xrefs. Note these are options of the **`generate`
+    subcommand**: placed before it, Antora reads them as stray positional arguments and
+    dies with "too many arguments for 'generate'"
+  - Asciidoctor reports a dangling *internal* reference — `<<some-anchor>>` where that
+    anchor is not on the page — at **`info`**, and `failure_level` accepts only
+    warn/error/fatal/none, so that class can never fail on Antora's exit code alone.
+    `scripts/docs/validateXrefs.js` wraps the validator, runs it at
+    `--log-level=info --log-format=json`, and fails on any reference message whatever
+    level it was logged at. `collectProblems` is exported and covered by
+    `src/test/docs/validate_xrefs.spec.ts`. This is the gap that let
+    `getting_started/importing.adoc` link to `#upgrade-dashboards` — an anchor on
+    `installation/upgrading.adoc` — while CI stayed green
+- `<<module:page.adoc#anchor, text>>` **is** valid in Antora and resolves to a proper
+  cross-page link; a static "is this anchor on this page" check flags those as broken and
+  is wrong. What is actually broken is a bare `<<anchor>>` naming an anchor on a
+  *different* page: it renders as `href="#anchor"` and goes nowhere. Prefer
+  `xref:module:page.adoc#anchor[text]` for anything cross-page. Antora validates the
+  page half of an xref target, never the `#anchor` half, so a wrong anchor with a right
+  page is still silent
 - The docs UI bundle comes from `OpenNMS/antora-ui-opennms` (v3.1.1), matching
   `antora-playbook-local.yml` in the main OpenNMS repo. The old
   `opennms-forge/antora-ui-opennms` bundle is a different repo whose newest release is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,12 @@ A full reinstall also re-resolves every `^` range, so it can surface breakage un
   first (it needs `debhelper` anyway); the orb passes `-o APT::Get::List-Cleanup=0`, so
   those lists survive into its own call. Do not drop that step
 - `build-docs` runs on `node-executor` and takes Antora from this repo's own `@antora`
-  devDependencies. There is deliberately no `docs-executor`: every `opennms/antora` tag,
+  devDependencies, so it **must install them itself**: the job requires only `pre-build`,
+  which checks out and never runs `npm ci`. That did not matter while the antora image
+  carried Antora globally, and it is why the first attempt failed in CI with
+  `spawnSync .../node_modules/.bin/antora ENOENT` while passing locally against a tree
+  that already had `node_modules`. Verify docs changes against a clean clone, not the
+  working tree. There is deliberately no `docs-executor`: every `opennms/antora` tag,
   newest included, is Alpine 3.18 on **Node 16**, and Antora 3.2 requires Node >= 20, so
   that image cannot run current Antora at all. Do **not** reintroduce it. The symptom it
   produced was `diagChan.tracingChannel is not a function` out of `pino` — the CLI

--- a/docs/modules/getting_started/pages/importing.adoc
+++ b/docs/modules/getting_started/pages/importing.adoc
@@ -36,4 +36,4 @@ The dashboard is displayed.
 To view a list of your dashboards, click menu:Dashboards[Manage].
 
 IMPORTANT: Predefined dashboards created before April 2023 require conversion before you can use them with {product-name}.
-You must export and <<upgrade-dashboards, convert these dashboards>> before using them.
+You must export and xref:installation:upgrading.adoc#upgrade-dashboards[convert these dashboards] before using them.

--- a/local-site.yml
+++ b/local-site.yml
@@ -9,7 +9,7 @@ content:
     start_path: docs
 ui:
   bundle:
-    url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v3.1.0/ui-bundle.zip
+    url: https://github.com/OpenNMS/antora-ui-opennms/releases/download/v3.1.1/ui-bundle.zip
 asciidoc:
   attributes:
     experimental: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,9 @@
         "react-router-dom": "^7.18.2"
       },
       "devDependencies": {
-        "@antora/cli": "^3.1.14",
-        "@antora/site-generator": "^3.1.14",
-        "@antora/site-generator-default": "^3.1.12",
+        "@antora/cli": "^3.2.0",
+        "@antora/site-generator": "^3.2.0",
+        "@antora/site-generator-default": "^3.2.0",
         "@babel/core": "^7.29.7",
         "@grafana/e2e-selectors": "^12.4.0",
         "@grafana/eslint-config": "^8.2.0",
@@ -147,55 +147,65 @@
       }
     },
     "node_modules/@antora/asciidoc-loader": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@antora/asciidoc-loader/-/asciidoc-loader-3.1.15.tgz",
-      "integrity": "sha512-MVspbcMPmBgxZms0EjmyC9nlCAWBJfHYSwQCXRZn6T7OujRrLvJFPgz+EROz9XOqh4v76BeqgEuLsUJIZjH3cw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@antora/asciidoc-loader/-/asciidoc-loader-3.2.0.tgz",
+      "integrity": "sha512-IaxhqSl9CvAi5Ieqt3Kc1SlJ11iq4kkWNFAAwUFCv/9L0WbzoczQ+o0y0W2lEONXVCKOBT1yzFBi55149SNwUQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/logger": "3.1.15",
+        "@antora/logger": "3.2.0",
         "@antora/user-require-helper": "~3.0",
         "@asciidoctor/core": "~2.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@antora/cli": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@antora/cli/-/cli-3.1.15.tgz",
-      "integrity": "sha512-76vLhkyzyFd49WJHsC04oPAZlK4qWbJaeZdS/pLUUVBqgaxeSeNqpTZ0pXo7f+5laGRO19fXyk1eDWGus9h8jA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@antora/cli/-/cli-3.2.0.tgz",
+      "integrity": "sha512-bJ5Vl+FMH52xm2jxdcbrEUN3aeoIYj5NGzLGsVwIPewM0RXee0kckbToAFnU0EK0Uw07cBomiJ5hwVELex0/ug==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/logger": "3.1.15",
-        "@antora/playbook-builder": "3.1.15",
+        "@antora/logger": "3.2.0",
+        "@antora/playbook-builder": "3.2.0",
         "@antora/user-require-helper": "~3.0",
-        "commander": "~11.1"
+        "commander": "~14.0"
       },
       "bin": {
         "antora": "bin/antora"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@antora/cli/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@antora/content-aggregator": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@antora/content-aggregator/-/content-aggregator-3.1.15.tgz",
-      "integrity": "sha512-w84rJRKx+C4dsSbOHmjg78oM2T6xP9JRDsxpXjTmlh9T4zlNELCB6AD5s6Gztt3S6wlTiCNFLZw0v/HEVtuhzQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@antora/content-aggregator/-/content-aggregator-3.2.0.tgz",
+      "integrity": "sha512-Q7lTjNFlpQx3SWW8QbNv5P4f1DhiKhYY3PyMifRHc4npuILOU0q4+kmlO1W1swSDDCg5pDjmgwitwAi9VQgvhg==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "@antora/expand-path-helper": "~3.0",
-        "@antora/logger": "3.1.15",
+        "@antora/logger": "3.2.0",
         "@antora/user-require-helper": "~3.0",
         "braces": "~3.0",
         "cache-directory": "~2.0",
         "fast-glob": "~3.3",
         "hpagent": "~1.2",
-        "isomorphic-git": "~1.25",
-        "js-yaml": "~4.1",
+        "isomorphic-git": "~1.38",
+        "js-yaml": "~5.4",
         "multi-progress": "~4.0",
         "picomatch": "~4.0",
         "progress": "~2.0",
@@ -204,36 +214,86 @@
         "vinyl": "~3.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@antora/content-aggregator/node_modules/js-yaml": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/@antora/content-classifier": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@antora/content-classifier/-/content-classifier-3.1.15.tgz",
-      "integrity": "sha512-m7INbqJcXBZU04HdBMqfL/NvezC3aaJGHHa0KfzeEKICg5FT22cVsEp6mYTgJVT4HqRy7JPCn9UeZvoa9x+MzQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@antora/content-classifier/-/content-classifier-3.2.0.tgz",
+      "integrity": "sha512-fUrh08qpgbsjV7noFTWDQaevLC2NAs3gHRJbaTTvULEb+OZRCB0LjEPyvhIAk1wKwkfPqcnjAShJHurH/gXPCg==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/asciidoc-loader": "3.1.15",
-        "@antora/logger": "3.1.15",
-        "mime-types": "~2.1",
+        "@antora/asciidoc-loader": "3.2.0",
+        "@antora/logger": "3.2.0",
+        "mime-types": "~3.0",
         "vinyl": "~3.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@antora/content-classifier/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@antora/content-classifier/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@antora/document-converter": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@antora/document-converter/-/document-converter-3.1.15.tgz",
-      "integrity": "sha512-7YZsc/iIJVTxvHKy0/eqPTuRIJupBd7Pq49gWvCxiDBR9Zj4esqMZIU3HaIbkBgqJLlQv5TLBeTjiQ1Qpe1hNw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@antora/document-converter/-/document-converter-3.2.0.tgz",
+      "integrity": "sha512-+cwQxIIRNI9+BXHk2fff/jvBd17p/AHslAT02ic6tWlgRaORc5y5/dRK+Q9hSjE6vpndE92gyokRn2zsigOUDg==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/asciidoc-loader": "3.1.15"
+        "@antora/asciidoc-loader": "3.2.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@antora/expand-path-helper": {
@@ -247,9 +307,9 @@
       }
     },
     "node_modules/@antora/file-publisher": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@antora/file-publisher/-/file-publisher-3.1.15.tgz",
-      "integrity": "sha512-UfLYeyD6Na9YXespr3Xjy6OPIAGG6GTbdW3SNn8KxHl3hGeF/AtM3NaR+AJgyOmTb2r9lHzfODXeZevqX+vMww==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@antora/file-publisher/-/file-publisher-3.2.0.tgz",
+      "integrity": "sha512-UqKzDI2JR/Ms88kgUteyqvIikekDBoZZGPo8L79GpvffPBP2CJmhCSSue1IuV0aFtobHuCgWqWtHzsdhy7KJ6Q==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -259,152 +319,173 @@
         "yazl": "~3.3"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@antora/logger": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@antora/logger/-/logger-3.1.15.tgz",
-      "integrity": "sha512-txA2Nv0QQ+hIt6arc3Rrh1BiUJNlucsyNF7ZA7LgtN+rzxyjcqQPpbQ2F3tU2lOV/LOQCEvMbmz9Dj0tY8oBuA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@antora/logger/-/logger-3.2.0.tgz",
+      "integrity": "sha512-2+bTFjYOuwoWjgtIfpf8bit6OuizI7O8RnXsHzX2y6/PBbm9K8ulvmqtnFk8933P5ILTZ/NSrbgvcFz5BXrY8A==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "@antora/expand-path-helper": "~3.0",
-        "pino": "~9.2",
-        "pino-pretty": "~11.2",
-        "sonic-boom": "~4.0"
+        "pino": "~10.3"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@antora/navigation-builder": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@antora/navigation-builder/-/navigation-builder-3.1.15.tgz",
-      "integrity": "sha512-XRs4pfNd88GCG9lDAJ1J+2vwvre7OzNRSgRmZhEhtgv0A13NEZq37X4YuaH46F2kj2BqiZT8UOuxqAqarLaxmg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@antora/navigation-builder/-/navigation-builder-3.2.0.tgz",
+      "integrity": "sha512-W7TI0e2doDwpF7YYsYUYJtxFQfDre4egU33eOM8Y7ZEUaAZBweOCiANFgZmfZiCvM3nswLyBtMJqvVzAc8vPTg==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/asciidoc-loader": "3.1.15"
+        "@antora/asciidoc-loader": "3.2.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@antora/page-composer": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@antora/page-composer/-/page-composer-3.1.15.tgz",
-      "integrity": "sha512-koKlhWilA0E0QdCCOeLLzCFLNViBVjNe3aIlmJnMCwAK0p85wyhVfyolNqbNejAvdCZ87YhUQJ52Q4ikCgkQQg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@antora/page-composer/-/page-composer-3.2.0.tgz",
+      "integrity": "sha512-cBr9wYnF6ba4fbbVvs+fR/88BPoqFB9bxdU2z2kWXDsAkQIT/OHLauo+UY+H5+pw/SET1A9bOwMaNlvM4mvfxg==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/logger": "3.1.15",
-        "handlebars": "~4.7",
-        "require-from-string": "~2.0"
+        "@antora/logger": "3.2.0",
+        "handlebars": "~4.7"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@antora/playbook-builder": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@antora/playbook-builder/-/playbook-builder-3.1.15.tgz",
-      "integrity": "sha512-L2bE9FS0Th/d37DeDjz/dg9YXrkHM1xI0WQB3eiW3K/6d0Mc7eJhbmDMT0K8S+hgdaO0AT4kqDWzvx2866ZobA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@antora/playbook-builder/-/playbook-builder-3.2.0.tgz",
+      "integrity": "sha512-mAOrE+vDRa0wUcTc3JIZWvEai69vZ1kx6CvZi8ugSYrcWbZxNDp+R5pYWRX9037dZ5e6s5hKKGV503thm9BiSw==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "@iarna/toml": "~2.2",
         "convict": "~6.2",
-        "js-yaml": "~4.1",
+        "js-yaml": "~5.4",
         "json5": "~2.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@antora/playbook-builder/node_modules/js-yaml": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/@antora/redirect-producer": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@antora/redirect-producer/-/redirect-producer-3.1.15.tgz",
-      "integrity": "sha512-mV0KnRiTr9oi0hPm7okT/Bw8kkz+PWYxp9AVSGqzhkoQgr3crxhgyS0NFCoViHwjaj4NfQrf++yxbhr6Igd7Dw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@antora/redirect-producer/-/redirect-producer-3.2.0.tgz",
+      "integrity": "sha512-soJbguowD3r7rCMn/r6OMiphXXUwNXUE9MeR6xrDa1RnoTu5mNALIhgI4mBid1CZ/jb+tnJ0WQWVArM1d9EmKw==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
+        "@antora/content-classifier": "3.2.0",
         "vinyl": "~3.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@antora/site-generator": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@antora/site-generator/-/site-generator-3.1.15.tgz",
-      "integrity": "sha512-Z9YiRTqw3ssnLQxSHI3VZHEPLytQXt8cWC5C/o9vS+Fc560TSNs1UO4quPFIkg+bFUpxXtcAxqbp650aA4/N1g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@antora/site-generator/-/site-generator-3.2.0.tgz",
+      "integrity": "sha512-bgShOpARuO+1MF50HUsv25C7msyZk6GpaP2EBcjqD3s0Dj51amQL5KMqAbwfKLjTCiAUTGpC/Yb8rGeogUnmYw==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/asciidoc-loader": "3.1.15",
-        "@antora/content-aggregator": "3.1.15",
-        "@antora/content-classifier": "3.1.15",
-        "@antora/document-converter": "3.1.15",
-        "@antora/file-publisher": "3.1.15",
-        "@antora/logger": "3.1.15",
-        "@antora/navigation-builder": "3.1.15",
-        "@antora/page-composer": "3.1.15",
-        "@antora/playbook-builder": "3.1.15",
-        "@antora/redirect-producer": "3.1.15",
-        "@antora/site-mapper": "3.1.15",
-        "@antora/site-publisher": "3.1.15",
-        "@antora/ui-loader": "3.1.15",
+        "@antora/asciidoc-loader": "3.2.0",
+        "@antora/content-aggregator": "3.2.0",
+        "@antora/content-classifier": "3.2.0",
+        "@antora/document-converter": "3.2.0",
+        "@antora/file-publisher": "3.2.0",
+        "@antora/logger": "3.2.0",
+        "@antora/navigation-builder": "3.2.0",
+        "@antora/page-composer": "3.2.0",
+        "@antora/playbook-builder": "3.2.0",
+        "@antora/redirect-producer": "3.2.0",
+        "@antora/site-mapper": "3.2.0",
+        "@antora/site-publisher": "3.2.0",
+        "@antora/ui-loader": "3.2.0",
         "@antora/user-require-helper": "~3.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@antora/site-generator-default": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@antora/site-generator-default/-/site-generator-default-3.1.15.tgz",
-      "integrity": "sha512-rXCVv513b617kKu8dVAxeDUKhtkzRujTICzjuDEy/sfAnHuFLcuR169lPS6qYdN/uOh4P6cXyBBzVw4F6JvyyA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@antora/site-generator-default/-/site-generator-default-3.2.0.tgz",
+      "integrity": "sha512-cMCFjbtg1GTsgGBgGdG4V53hmJfT/IbLnfFsC/Jyy8FCQa/OiTtVgovk6ZesYdz61K32PiXWYTm2zEORYHwhow==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/site-generator": "3.1.15"
+        "@antora/site-generator": "3.2.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@antora/site-mapper": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@antora/site-mapper/-/site-mapper-3.1.15.tgz",
-      "integrity": "sha512-dV5zGeL1uMQ83sfkBWKg8vjaJQXz1Zh3ZSNQZYa64HnT4M7oSuQUzwDZdS0j6ZtTiYcNGulRi1ucz3uIoc9tqw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@antora/site-mapper/-/site-mapper-3.2.0.tgz",
+      "integrity": "sha512-ZnBl03Ha5dLlduVoKGC2kn+n0o8IPwoMzSbu+rLok+uzEPR2La7fQXNJa9exNzBtnE2GnNkj37jJg6YHQpIUiw==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/content-classifier": "3.1.15",
+        "@antora/content-classifier": "3.2.0",
         "vinyl": "~3.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@antora/site-publisher": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@antora/site-publisher/-/site-publisher-3.1.15.tgz",
-      "integrity": "sha512-pBuNxgA+H+WB5F4gA/gim5wKx/884QwlqOl0CpOY+6Fqn7h2ooHA7Tv6O47Tra1nZzNbIe3CQRoA5pnrX6zyRw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@antora/site-publisher/-/site-publisher-3.2.0.tgz",
+      "integrity": "sha512-zXYxyH0+NuhaPnGReDvL8CCmYPsocxSKn3HeE3Z39lrexK/qSajliUGYW0jP9IRi+cCFXpvuC7PDYtQfZDvWaw==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/file-publisher": "3.1.15"
+        "@antora/file-publisher": "3.2.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@antora/ui-loader": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@antora/ui-loader/-/ui-loader-3.1.15.tgz",
-      "integrity": "sha512-zYjF5ID7t6mUEJuMyeNW/AYu1U0026wZj58H0siGuaT5YhVoxZrfvZYWV5iCMntpKduMqkwZW/l+D4MIqjhFYQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@antora/ui-loader/-/ui-loader-3.2.0.tgz",
+      "integrity": "sha512-EYagiuG2Tk5QtnG/rwTzu/8mxDtL8J2oqZc74g0h4h3iatJeD8yNrDc8iDhNaycEZNaxPRfIK73tpKuIFZw+Iw==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -413,15 +494,38 @@
         "cache-directory": "~2.0",
         "fast-glob": "~3.3",
         "hpagent": "~1.2",
-        "js-yaml": "~4.1",
+        "js-yaml": "~5.4",
         "picomatch": "~4.0",
         "should-proxy": "~1.0",
         "simple-get": "~4.0",
         "vinyl": "~3.0",
-        "yauzl": "~3.3"
+        "yauzl": "~3.4"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@antora/ui-loader/node_modules/js-yaml": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/@antora/user-require-helper": {
@@ -7178,6 +7282,31 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-crc32": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
@@ -8314,16 +8443,6 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
-    "node_modules/dateformat": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
-      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -9431,13 +9550,6 @@
       "integrity": "sha512-/DCilZlUdz2XyNDF+ASs0PwY+RKG9Y4Silp/gbS72Cvbg4oibc778xcecg+pnNyiNHYgh/TApsiDTjpdniyShw==",
       "license": "MIT"
     },
-    "node_modules/fast-copy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
-      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9493,13 +9605,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "license": "MIT"
     },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-shallow-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
@@ -9538,9 +9643,9 @@
       "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
+      "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -10350,13 +10455,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/help-me": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
-      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/highlight-words-core": {
       "version": "1.2.3",
@@ -11322,9 +11420,9 @@
       "license": "MIT"
     },
     "node_modules/isomorphic-git": {
-      "version": "1.25.10",
-      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.25.10.tgz",
-      "integrity": "sha512-IxGiaKBwAdcgBXwIcxJU6rHLk+NrzYaaPKXXQffcA0GW3IUrQXdUPDXDo+hkGVcYruuz/7JlGBiuaeTCgIgivQ==",
+      "version": "1.38.10",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.38.10.tgz",
+      "integrity": "sha512-nJSSq7ypu97vM33rSdxXyPzSWksCberjKspzXhFEcBHdVyxdNkWByAzJ/AURV1jIlfv8pLq37lGdIEt7ORj17Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11336,15 +11434,15 @@
         "minimisted": "^2.0.0",
         "pako": "^1.0.10",
         "pify": "^4.0.1",
-        "readable-stream": "^3.4.0",
-        "sha.js": "^2.4.9",
+        "readable-stream": "^4.0.0",
+        "sha.js": "^2.4.12",
         "simple-get": "^4.0.1"
       },
       "bin": {
         "isogit": "cli.cjs"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.17"
       }
     },
     "node_modules/isomorphic-git/node_modules/ignore": {
@@ -14652,16 +14750,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/joycon": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
-      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jquery": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
@@ -16177,85 +16265,6 @@
         "split2": "^4.0.0"
       }
     },
-    "node_modules/pino-pretty": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-11.2.2.tgz",
-      "integrity": "sha512-2FnyGir8nAJAqD3srROdrF1J5BIcMT4nwj7hHSc60El6Uxlym00UbCCd8pYIterstVBFlMyF1yFV8XdGIPbj4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "colorette": "^2.0.7",
-        "dateformat": "^4.6.3",
-        "fast-copy": "^3.0.2",
-        "fast-safe-stringify": "^2.1.1",
-        "help-me": "^5.0.0",
-        "joycon": "^3.1.1",
-        "minimist": "^1.2.6",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^1.0.0",
-        "pump": "^3.0.0",
-        "readable-stream": "^4.0.0",
-        "secure-json-parse": "^2.4.0",
-        "sonic-boom": "^4.0.1",
-        "strip-json-comments": "^3.1.1"
-      },
-      "bin": {
-        "pino-pretty": "bin.js"
-      }
-    },
-    "node_modules/pino-pretty/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/pino-pretty/node_modules/pino-abstract-transport": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^4.0.0",
-        "split2": "^4.0.0"
-      }
-    },
-    "node_modules/pino-pretty/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/pino-std-serializers": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
@@ -17325,18 +17334,20 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/readdirp": {
@@ -18076,13 +18087,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/secure-json-parse": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
-      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/selection-is-backward": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/selection-is-backward/-/selection-is-backward-1.0.0.tgz",
@@ -18542,9 +18546,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.0.1.tgz",
-      "integrity": "sha512-hTSD/6JMLyT4r9zeof6UtuBDpjJ9sO08/nmS5djaA9eozT9oOlNdpXSnzcgj4FTqpk3nkLrs61l4gip9r1HCrQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20819,9 +20823,9 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.2.tgz",
-      "integrity": "sha512-Md9ankxxN23wncAN8s7+Tn3Co52zLUPMtnrLAbVCnfG5d2tKBFfmygYSgXlqFgXObtzIgqkx7aNgDBpso9+4qA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "async": "^3.2.3",
         "lodash.clonedeep": "^4.5.0",
         "lodash.escaperegexp": "^4.1.2",
-        "opennms": "^2.6.1",
+        "opennms": "^2.7.0",
         "parenthesis": "^3.1.8",
         "perfect-scrollbar": "^1.5.5",
         "react": "~18.3.1",
@@ -1553,6 +1553,28 @@
         "node": ">= 4"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2298,9 +2320,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9914,6 +9936,29 @@
         "node": ">=12"
       }
     },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -9955,12 +10000,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/fs": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.2.tgz",
-      "integrity": "sha512-YAiVokMCrSIFZiroB1oz51hPiPRVcUtSa4x2U5RYXyhS9VAPdiFigKbPTnOSq7XY8wd3FIVPYmXpo5lMzFmxgg==",
-      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "11.4.0",
@@ -14768,28 +14807,6 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
-    "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
@@ -15897,23 +15914,22 @@
       }
     },
     "node_modules/opennms": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/opennms/-/opennms-2.6.1.tgz",
-      "integrity": "sha512-zxQ/OCKkI3u7C/uGHTbG4DmiO02ZNPJsXlGS/A45YX3gPm1zHe5ssx1EQKSeDo/L6NudTD1WSn+zIz96XSk0xw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/opennms/-/opennms-2.7.0.tgz",
+      "integrity": "sha512-qjQ63BV466+HpjTPLXuT5IVYOpJXwrxsiviUiR/yDoftdmeWaqfo8wToKYtqSjl/t7tubDlad7OzE+qO1zf+XQ==",
       "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.9.3",
-        "axios": "^1.13.0",
+        "@xmldom/xmldom": "^0.9.12",
+        "axios": "^1.20.0",
         "btoa": "^1.2.1",
         "commander": "^12.1.0",
-        "fs": "^0.0.2",
         "html-to-formatted-text": "^2.7.0",
-        "ip-address": "^10.0.1",
-        "lodash": "^4.17.21",
+        "ip-address": "^10.5.0",
+        "lodash": "^4.18.1",
         "moment": "^2.30.1",
         "object-hash": "^3.0.0",
         "picocolors": "^1.1.1",
-        "qs": "^6.13.1",
+        "qs": "^6.15.3",
         "regenerator-runtime": "^0.14.1",
         "table": "^6.9.0",
         "version_compare": "^0.0.3",
@@ -15923,7 +15939,8 @@
         "opennms": "dist/cli.node.js"
       },
       "engines": {
-        "node": ">=20 <=23"
+        "node": ">=20 <=23",
+        "npm": ">=10"
       }
     },
     "node_modules/opennms/node_modules/commander": {
@@ -16737,9 +16754,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:ci": "jest --passWithNoTests --maxWorkers 4",
     "test:watch": "jest --watch --onlyChanged",
     "typecheck": "tsc --noEmit",
+    "validate-anchors": "node ./scripts/docs/validateAnchors.js public",
     "validate-xrefs": "npm install --no-save --no-audit --no-fund --omit=optional --prefix .antora-tools \"https://gitlab.com/antora/xref-validator/-/archive/9081e3ca3f6c6cbe9d379680ee67cc72db7a1f53/xref-validator-9081e3ca3f6c6cbe9d379680ee67cc72db7a1f53.tar.gz\" && node ./scripts/docs/validateXrefs.js local-site.yml",
     "watch": "webpack -w -c ./webpack.config.ts --env development"
   },

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "test:ci": "jest --passWithNoTests --maxWorkers 4",
     "test:watch": "jest --watch --onlyChanged",
     "typecheck": "tsc --noEmit",
-    "validate-xrefs": "antora --generator @antora/xref-validator local-site.yml",
+    "validate-xrefs": "npm install --no-save --no-audit --no-fund --omit=optional --prefix .antora-tools \"https://gitlab.com/antora/xref-validator/-/archive/9081e3ca3f6c6cbe9d379680ee67cc72db7a1f53/xref-validator-9081e3ca3f6c6cbe9d379680ee67cc72db7a1f53.tar.gz\" && antora --log-failure-level=error --generator ./.antora-tools/node_modules/@antora/xref-validator local-site.yml",
     "watch": "webpack -w -c ./webpack.config.ts --env development"
   },
   "devDependencies": {
-    "@antora/cli": "^3.1.14",
-    "@antora/site-generator": "^3.1.14",
-    "@antora/site-generator-default": "^3.1.12",
+    "@antora/cli": "^3.2.0",
+    "@antora/site-generator": "^3.2.0",
+    "@antora/site-generator-default": "^3.2.0",
     "@babel/core": "^7.29.7",
     "@grafana/e2e-selectors": "^12.4.0",
     "@grafana/eslint-config": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "async": "^3.2.3",
     "lodash.clonedeep": "^4.5.0",
     "lodash.escaperegexp": "^4.1.2",
-    "opennms": "^2.6.1",
+    "opennms": "^2.7.0",
     "parenthesis": "^3.1.8",
     "perfect-scrollbar": "^1.5.5",
     "react": "~18.3.1",
@@ -202,8 +202,8 @@
     },
     "ip-address": "^10.3.1",
     "js-cookie": "^3.0.8",
-    "js-yaml@^3.0.0": "^3.15.1",
-    "js-yaml@^4.0.0": "^4.3.1",
+    "js-yaml@^3.0.0": "^3.15.2",
+    "js-yaml@^4.0.0": "^4.3.2",
     "lodash": "^4.18.0",
     "maximatch": {
       "minimatch": "^3.1.4"
@@ -215,7 +215,7 @@
     "opennms": {
       "ajv": "^8.18.0",
       "axios": "^1.18.0",
-      "qs": "^6.15.2",
+      "qs": "^6.16.0",
       "striptags": "^3.2.0"
     },
     "picomatch@^2.0.0": "^2.3.2",
@@ -234,10 +234,10 @@
       "serialize-javascript": "^7.0.5"
     },
     "tiny-lr": {
-      "qs": "^6.15.2"
+      "qs": "^6.16.0"
     },
     "webpack-livereload-plugin": {
-      "qs": "^6.15.2"
+      "qs": "^6.16.0"
     },
     "websocket-driver": "^0.7.5",
     "ws": "^8.21.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",
     "dev": "webpack -c ./webpack.config.ts --env development",
-    "docs": "antora --stacktrace generate local-site.yml",
+    "docs": "antora --stacktrace generate --log-level=info --log-failure-level=warn local-site.yml",
     "e2e": "playwright test",
     "e2e:update": "playwright test --update-screenshots",
     "lint": "eslint --cache --ignore-pattern './.gitignore' --ignore-pattern 'public/**' --ext .js,.jsx,.ts,.tsx .",
@@ -33,7 +33,7 @@
     "test:ci": "jest --passWithNoTests --maxWorkers 4",
     "test:watch": "jest --watch --onlyChanged",
     "typecheck": "tsc --noEmit",
-    "validate-xrefs": "npm install --no-save --no-audit --no-fund --omit=optional --prefix .antora-tools \"https://gitlab.com/antora/xref-validator/-/archive/9081e3ca3f6c6cbe9d379680ee67cc72db7a1f53/xref-validator-9081e3ca3f6c6cbe9d379680ee67cc72db7a1f53.tar.gz\" && antora --log-failure-level=error --generator ./.antora-tools/node_modules/@antora/xref-validator local-site.yml",
+    "validate-xrefs": "npm install --no-save --no-audit --no-fund --omit=optional --prefix .antora-tools \"https://gitlab.com/antora/xref-validator/-/archive/9081e3ca3f6c6cbe9d379680ee67cc72db7a1f53/xref-validator-9081e3ca3f6c6cbe9d379680ee67cc72db7a1f53.tar.gz\" && node ./scripts/docs/validateXrefs.js local-site.yml",
     "watch": "webpack -w -c ./webpack.config.ts --env development"
   },
   "devDependencies": {

--- a/scripts/docs/validateAnchors.js
+++ b/scripts/docs/validateAnchors.js
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+'use strict';
+
+// Checks that every in-page anchor the built docs link to actually exists.
+//
+// Antora validates the *page* half of an xref target and never the `#anchor`
+// half, so `xref:installation:upgrading.adoc#typo[]` resolves the page, renders a
+// link to nowhere and reports nothing -- at any log level. That is the last silent
+// class of broken reference, and scripts/docs/validateXrefs.js cannot see it.
+//
+// This works on the generated HTML rather than the AsciiDoc source on purpose.
+// Anchors come from auto-generated section ids (subject to idprefix/idseparator),
+// `[[x]]`, `[#x]`, block ids and discrete headings; deriving that set from source
+// means reimplementing Asciidoctor, and getting it wrong reports links that are in
+// fact perfectly good. The rendered `id` attributes are ground truth.
+//
+// Run it after `npm run docs`, which is what produces the site it reads.
+
+const fs = require('fs');
+const path = require('path');
+
+const PROJECT_DIR = path.resolve(__dirname, '..', '..');
+const DEFAULT_SITE_DIR = path.join(PROJECT_DIR, 'public');
+
+// The UI bundle's assets. No pages, and its ids are not ours to police.
+const UI_ASSET_DIR = '_';
+
+// Anything with a scheme (http:, https:, mailto:, tel:, javascript:) or
+// protocol-relative is not a link into the built site.
+const HAS_SCHEME = /^([a-z][a-z0-9+.-]*:|\/\/)/i;
+
+// Asciidoctor generates these itself, in matched pairs; they are not authored.
+const GENERATED_FRAGMENT = /^_footnote(?:def|ref)_\d+$/;
+
+function collectIds(html) {
+  const ids = new Set();
+
+  for (const match of html.matchAll(/\s(?:id|name)="([^"]*)"/g)) {
+    if (match[1] !== '') {
+      ids.add(match[1]);
+    }
+  }
+
+  return ids;
+}
+
+function extractAnchorLinks(html) {
+  const links = [];
+
+  for (const match of html.matchAll(/\shref="([^"]*)"/g)) {
+    if (match[1].includes('#')) {
+      links.push(match[1]);
+    }
+  }
+
+  return links;
+}
+
+// Returns the file the fragment must live in and the fragment itself, or null when
+// the link is not ours to check.
+function resolveTarget(pageFile, href) {
+  if (HAS_SCHEME.test(href)) {
+    return null;
+  }
+
+  const hashAt = href.indexOf('#');
+  const relative = href.slice(0, hashAt);
+  const raw = href.slice(hashAt + 1);
+
+  // `href="#"` is a chrome affordance (dropdown toggles), not a reference.
+  if (raw === '') {
+    return null;
+  }
+
+  let fragment = raw;
+
+  try {
+    fragment = decodeURIComponent(raw);
+  } catch {
+    // A fragment that is not valid percent-encoding is still worth checking as
+    // written, so fall through with the raw value rather than skipping the link.
+  }
+
+  if (GENERATED_FRAGMENT.test(fragment)) {
+    return null;
+  }
+
+  let file;
+
+  if (relative === '') {
+    file = pageFile;
+  } else if (relative.endsWith('/')) {
+    file = path.resolve(path.dirname(pageFile), relative, 'index.html');
+  } else {
+    file = path.resolve(path.dirname(pageFile), relative);
+  }
+
+  return { file, fragment };
+}
+
+function listHtmlFiles(dir) {
+  const files = [];
+
+  const walk = (current) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+
+      if (entry.isDirectory()) {
+        if (entry.name !== UI_ASSET_DIR) {
+          walk(full);
+        }
+      } else if (entry.name.endsWith('.html')) {
+        files.push(full);
+      }
+    }
+  };
+
+  walk(dir);
+
+  return files.sort();
+}
+
+function findBrokenAnchors(siteDir = DEFAULT_SITE_DIR) {
+  if (!fs.existsSync(siteDir)) {
+    throw new Error(
+      'validate-anchors: no built site at ' + siteDir + ' -- run `npm run docs` first'
+    );
+  }
+
+  const pages = listHtmlFiles(siteDir);
+  const idCache = new Map();
+  const problems = [];
+  let checked = 0;
+
+  const idsIn = (file) => {
+    if (!idCache.has(file)) {
+      if (fs.existsSync(file)) {
+        idCache.set(file, collectIds(fs.readFileSync(file, 'utf-8')));
+      } else {
+        idCache.set(file, null);
+      }
+    }
+
+    return idCache.get(file);
+  };
+
+  for (const page of pages) {
+    const html = fs.readFileSync(page, 'utf-8');
+
+    for (const href of extractAnchorLinks(html)) {
+      const target = resolveTarget(page, href);
+
+      if (target === null) {
+        continue;
+      }
+
+      checked += 1;
+
+      const ids = idsIn(target.file);
+
+      if (ids === null) {
+        problems.push({
+          page,
+          href,
+          reason: 'target page not found: ' + path.relative(siteDir, target.file)
+        });
+      } else if (!ids.has(target.fragment)) {
+        problems.push({
+          page,
+          href,
+          reason:
+            'no id="' +
+            target.fragment +
+            '" in ' +
+            (target.file === page ? 'this page' : path.relative(siteDir, target.file))
+        });
+      }
+    }
+  }
+
+  return { problems, checked, pages: pages.length };
+}
+
+function main() {
+  const siteDir = process.argv[2] ? path.resolve(process.argv[2]) : DEFAULT_SITE_DIR;
+
+  let result;
+
+  try {
+    result = findBrokenAnchors(siteDir);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+
+  if (result.problems.length) {
+    console.error(
+      'validate-anchors: ' +
+        result.problems.length +
+        ' broken anchor link(s) in ' +
+        result.pages +
+        ' pages:'
+    );
+
+    for (const problem of result.problems) {
+      console.error(
+        '  ' +
+          path.relative(siteDir, problem.page) +
+          '  ->  ' +
+          problem.href +
+          '\n      ' +
+          problem.reason
+      );
+    }
+
+    process.exit(1);
+  }
+
+  console.log(
+    'validate-anchors: ' +
+      result.checked +
+      ' anchor links across ' +
+      result.pages +
+      ' pages, all resolved'
+  );
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { collectIds, extractAnchorLinks, resolveTarget, findBrokenAnchors };

--- a/scripts/docs/validateAnchors.js
+++ b/scripts/docs/validateAnchors.js
@@ -20,7 +20,8 @@
 const fs = require('fs');
 const path = require('path');
 
-const PROJECT_DIR = path.resolve(__dirname, '..', '..');
+const { PROJECT_DIR } = require('../paths');
+
 const DEFAULT_SITE_DIR = path.join(PROJECT_DIR, 'public');
 
 // The UI bundle's assets. No pages, and its ids are not ours to police.

--- a/scripts/docs/validateAnchors.js
+++ b/scripts/docs/validateAnchors.js
@@ -36,7 +36,18 @@ const GENERATED_FRAGMENT = /^_footnote(?:def|ref)_\d+$/;
 function collectIds(html) {
   const ids = new Set();
 
-  for (const match of html.matchAll(/\s(?:id|name)="([^"]*)"/g)) {
+  for (const match of html.matchAll(/\sid="([^"]*)"/g)) {
+    if (match[1] !== '') {
+      ids.add(match[1]);
+    }
+  }
+
+  // `name` counts only on <a>. Harvesting it everywhere makes every page's
+  // <meta name="description">, <meta name="generator"> and <meta name="viewport">
+  // into anchors, so `#description` -- a plausible typo for a section whose real id
+  // is `_description` -- resolves silently on all 26 pages. Asciidoctor emits `id`
+  // for anchors; `<a name=>` is only here for hand-written passthrough HTML.
+  for (const match of html.matchAll(/<a\s[^>]*\bname="([^"]*)"/g)) {
     if (match[1] !== '') {
       ids.add(match[1]);
     }
@@ -83,6 +94,18 @@ function resolveTarget(pageFile, href) {
   }
 
   if (GENERATED_FRAGMENT.test(fragment)) {
+    return null;
+  }
+
+  // A root-relative href is resolved against the published site URL, not the output
+  // directory. Antora writes `/grafana-plugin/_/css/site.css` for a file that lives at
+  // <siteDir>/_/css/site.css, because site.url contributes the `/grafana-plugin`
+  // prefix. So resolving one against the page escapes siteDir entirely, and resolving
+  // it against siteDir keeps a prefix that is not a directory -- both report a correct
+  // link as broken. Mapping it properly needs site.url, which this script deliberately
+  // does not read. Antora emits these for UI assets and the 404 page and never with a
+  // fragment, so skip rather than guess.
+  if (relative.startsWith('/')) {
     return null;
   }
 

--- a/scripts/docs/validateXrefs.js
+++ b/scripts/docs/validateXrefs.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+'use strict';
+
+// Runs Antora's xref validator and fails the build on any reference problem.
+//
+// This wrapper exists because --log-failure-level cannot express what we need.
+// Antora accepts only warn, error, fatal or none, but Asciidoctor reports a
+// dangling internal reference -- `<<some-anchor>>` where that anchor is not on the
+// page -- at *info* level. That is not a warning it can fail on, so a broken
+// reference was reported and the command still exited 0. That is exactly how
+// getting_started/importing.adoc came to link to `#upgrade-dashboards`, an anchor
+// that lives on installation/upgrading.adoc, for as long as it did.
+//
+// So: run Antora at --log-level=info with --log-failure-level=warn (which still
+// covers warn and above on its own), then treat the info-level reference messages
+// as failures too.
+
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const PROJECT_DIR = path.resolve(__dirname, '..', '..');
+
+// Only reference problems, not every info-level message Antora emits. Anything
+// Antora already fails on is left to Antora's own exit code.
+const REFERENCE_PROBLEM = /^(possible invalid reference|target of (?:xref|image|include) not found)\b/;
+
+const ANTORA = path.join(PROJECT_DIR, 'node_modules', '.bin', 'antora');
+const GENERATOR = path.join(
+  PROJECT_DIR,
+  '.antora-tools',
+  'node_modules',
+  '@antora',
+  'xref-validator'
+);
+
+// Antora logs one JSON object per line, but only when it decides not to pretty-print;
+// --log-format=json makes that unconditional so this does not depend on whether CI
+// happens to look like a TTY.
+function run(playbook) {
+  return spawnSync(
+    ANTORA,
+    [
+      '--log-level=info',
+      '--log-failure-level=warn',
+      '--log-format=json',
+      '--generator',
+      GENERATOR,
+      playbook
+    ],
+    { cwd: PROJECT_DIR, encoding: 'utf-8' }
+  );
+}
+
+// Exported so the parsing can be tested without running Antora.
+function collectProblems(output) {
+  return (output || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('{'))
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        // A line that is not JSON is not a log record; Antora's own exit code
+        // still covers anything that made it fail.
+        return null;
+      }
+    })
+    .filter((record) => record && REFERENCE_PROBLEM.test(record.msg || ''))
+    .map((record) => ({
+      msg: record.msg,
+      file: (record.file || {}).path || '<unknown file>'
+    }));
+}
+
+function main() {
+  const playbook = process.argv[2] || 'local-site.yml';
+  const result = run(playbook);
+
+  if (result.error) {
+    console.error('validate-xrefs: could not run antora: ' + result.error.message);
+    process.exit(1);
+  }
+
+  const combined = (result.stdout || '') + (result.stderr || '');
+
+  // Pass Antora's own output through; it is the useful diagnostic.
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+
+  const problems = collectProblems(combined);
+
+  if (problems.length) {
+    console.error(
+      '\nvalidate-xrefs: ' + problems.length + ' reference problem(s) found:'
+    );
+    problems.forEach((p) => {
+      console.error('  ' + path.relative(PROJECT_DIR, p.file) + ': ' + p.msg);
+    });
+    process.exit(1);
+  }
+
+  // Antora exits non-zero for warn and above on its own; do not mask that.
+  if (result.status !== 0) {
+    process.exit(result.status === null ? 1 : result.status);
+  }
+
+  console.log('validate-xrefs: no reference problems found');
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { collectProblems, REFERENCE_PROBLEM };

--- a/scripts/docs/validateXrefs.js
+++ b/scripts/docs/validateXrefs.js
@@ -19,7 +19,7 @@
 const path = require('path');
 const { spawnSync } = require('child_process');
 
-const PROJECT_DIR = path.resolve(__dirname, '..', '..');
+const { PROJECT_DIR } = require('../paths');
 
 // Only reference problems, not every info-level message Antora emits. Anything
 // Antora already fails on is left to Antora's own exit code.

--- a/scripts/docs/validateXrefs.js
+++ b/scripts/docs/validateXrefs.js
@@ -25,6 +25,12 @@ const PROJECT_DIR = path.resolve(__dirname, '..', '..');
 // Antora already fails on is left to Antora's own exit code.
 const REFERENCE_PROBLEM = /^(possible invalid reference|target of (?:xref|image|include) not found)\b/;
 
+// Antora records an absolute path for the file a message came from, but not on every
+// record. This stands in for the missing ones, and must not be run through
+// path.relative: that resolves it against the cwd and prints `../../..<cwd>/<unknown
+// file>` whenever the script is invoked from outside the project directory.
+const UNKNOWN_FILE = '<unknown file>';
+
 const ANTORA = path.join(PROJECT_DIR, 'node_modules', '.bin', 'antora');
 const GENERATOR = path.join(
   PROJECT_DIR,
@@ -70,8 +76,16 @@ function collectProblems(output) {
     .filter((record) => record && REFERENCE_PROBLEM.test(record.msg || ''))
     .map((record) => ({
       msg: record.msg,
-      file: (record.file || {}).path || '<unknown file>'
+      file: (record.file || {}).path || UNKNOWN_FILE
     }));
+}
+
+function describeLocation(file, projectDir = PROJECT_DIR) {
+  if (file === UNKNOWN_FILE) {
+    return file;
+  }
+
+  return path.relative(projectDir, file);
 }
 
 function main() {
@@ -99,8 +113,8 @@ function main() {
     console.error(
       '\nvalidate-xrefs: ' + problems.length + ' reference problem(s) found:'
     );
-    problems.forEach((p) => {
-      console.error('  ' + path.relative(PROJECT_DIR, p.file) + ': ' + p.msg);
+    problems.forEach((problem) => {
+      console.error('  ' + describeLocation(problem.file) + ': ' + problem.msg);
     });
     process.exit(1);
   }
@@ -117,4 +131,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { collectProblems, REFERENCE_PROBLEM };
+module.exports = { collectProblems, describeLocation, REFERENCE_PROBLEM, UNKNOWN_FILE };

--- a/scripts/paths.js
+++ b/scripts/paths.js
@@ -1,9 +1,10 @@
 'use strict';
 
-// The directories the packaging scripts work from, resolved once from this file's
-// own location. Everything under scripts/ is run both directly and through
-// `npm run package:*`, so process.cwd() is not a reliable base: it only agreed with
-// the project root while these scripts sat at the root, which they no longer do.
+// The directories the scripts under scripts/ work from, resolved once from this
+// file's own location. They run both directly and through npm scripts
+// (`npm run package:*`, `npm run validate-xrefs`), so process.cwd() is not a
+// reliable base: it only agreed with the project root while these scripts sat at
+// the root, which they no longer do.
 //
 // Deriving them here rather than in each module means a future move of scripts/ has
 // exactly one relative depth to update instead of one per consumer.

--- a/src/test/docs/validate_anchors.spec.ts
+++ b/src/test/docs/validate_anchors.spec.ts
@@ -40,6 +40,22 @@ describe('collectIds', () => {
   it('does not treat a substring of another attribute as an id', () => {
     expect(collectIds('<div data-id="nope">x</div>')).toEqual(new Set())
   })
+
+  it('ignores meta name attributes, which are not anchors', () => {
+    // Every Antora page carries these. Harvesting them made #description, #generator
+    // and #viewport resolve on all 26 built pages -- #description being a plausible
+    // typo for a section whose real id is _description.
+    const html =
+      '<meta name="description" content="x">' +
+      '<meta name="generator" content="Antora">' +
+      '<meta name="viewport" content="width=device-width">'
+
+    expect(collectIds(html)).toEqual(new Set())
+  })
+
+  it('still honours a name attribute on an anchor element', () => {
+    expect(collectIds('<a name="legacy"></a>')).toEqual(new Set(['legacy']))
+  })
 })
 
 describe('extractAnchorLinks', () => {
@@ -83,6 +99,14 @@ describe('resolveTarget', () => {
       file: '/site/docs/1.0/b.html',
       fragment: '100%'
     })
+  })
+
+  it('skips a root-relative href, which cannot be mapped without site.url', () => {
+    // Antora writes /grafana-plugin/_/css/site.css for a file at <siteDir>/_/css/site.css,
+    // because site.url contributes the prefix. Resolving against the page escapes the
+    // site dir; resolving against the site dir keeps a prefix that is not a directory.
+    // Either way a correct link gets reported as broken.
+    expect(resolveTarget(page, '/grafana-plugin/installation/upgrading.html#anchor')).toBeNull()
   })
 
   it.each([
@@ -148,6 +172,12 @@ describe('findBrokenAnchors', () => {
     // Antora writes a bare redirect page at the site root; it has no <article>, which
     // is why this checks whole pages instead of scoping to one element.
     writePage('index.html', '<h1>Redirect Notice</h1><a href="docs/1.0/a.html">go</a>')
+
+    expect(findBrokenAnchors(siteDir).problems).toEqual([])
+  })
+
+  it('does not report a root-relative link as broken', () => {
+    writePage('docs/1.0/a.html', '<a href="/site/docs/1.0/b.html#target">to b</a>')
 
     expect(findBrokenAnchors(siteDir).problems).toEqual([])
   })

--- a/src/test/docs/validate_anchors.spec.ts
+++ b/src/test/docs/validate_anchors.spec.ts
@@ -1,0 +1,158 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import {
+  collectIds,
+  extractAnchorLinks,
+  resolveTarget,
+  findBrokenAnchors
+} from '../../../scripts/docs/validateAnchors'
+
+let siteDir: string
+
+const writePage = (relativePath: string, body: string) => {
+  const target = path.join(siteDir, relativePath)
+  fs.mkdirSync(path.dirname(target), { recursive: true })
+  fs.writeFileSync(target, '<!DOCTYPE html><html><body>' + body + '</body></html>')
+}
+
+/** A site tree shaped like Antora's output: versioned component, UI assets under _. */
+const setUp = () => {
+  siteDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opg-anchors-test-'))
+  writePage('docs/1.0/a.html', '<h2 id="section-one">One</h2><a href="b.html#target">to b</a>')
+  writePage('docs/1.0/b.html', '<h2 id="target">Target</h2>')
+}
+
+const tearDown = () => fs.rmSync(siteDir, { recursive: true, force: true })
+
+beforeEach(setUp)
+afterEach(tearDown)
+
+describe('collectIds', () => {
+  it('collects both id and name attributes', () => {
+    expect(collectIds('<h2 id="one">x</h2><a name="two"></a>')).toEqual(new Set(['one', 'two']))
+  })
+
+  it('ignores empty values so href="#" cannot accidentally match', () => {
+    expect(collectIds('<div id="">x</div>')).toEqual(new Set())
+  })
+
+  it('does not treat a substring of another attribute as an id', () => {
+    expect(collectIds('<div data-id="nope">x</div>')).toEqual(new Set())
+  })
+})
+
+describe('extractAnchorLinks', () => {
+  it('returns only hrefs carrying a fragment', () => {
+    const html = '<a href="plain.html">a</a><a href="p.html#frag">b</a><a href="#local">c</a>'
+
+    expect(extractAnchorLinks(html)).toEqual(['p.html#frag', '#local'])
+  })
+})
+
+describe('resolveTarget', () => {
+  const page = '/site/docs/1.0/a.html'
+
+  it('resolves a fragment-only link against the page itself', () => {
+    expect(resolveTarget(page, '#here')).toEqual({ file: page, fragment: 'here' })
+  })
+
+  it('resolves a relative page link', () => {
+    expect(resolveTarget(page, '../2.0/b.html#here')).toEqual({
+      file: '/site/docs/2.0/b.html',
+      fragment: 'here'
+    })
+  })
+
+  it('resolves a directory link to its index.html', () => {
+    expect(resolveTarget(page, 'sub/#here')).toEqual({
+      file: '/site/docs/1.0/sub/index.html',
+      fragment: 'here'
+    })
+  })
+
+  it('percent-decodes the fragment', () => {
+    expect(resolveTarget(page, 'b.html#a%20b')).toEqual({
+      file: '/site/docs/1.0/b.html',
+      fragment: 'a b'
+    })
+  })
+
+  it('keeps a malformed fragment as written rather than skipping the link', () => {
+    expect(resolveTarget(page, 'b.html#100%')).toEqual({
+      file: '/site/docs/1.0/b.html',
+      fragment: '100%'
+    })
+  })
+
+  it.each([
+    ['https://example.com/x#frag'],
+    ['http://example.com/x#frag'],
+    ['mailto:a@b.c#frag'],
+    ['//example.com/x#frag'],
+    ['#'],
+    ['#_footnotedef_1'],
+    ['#_footnoteref_2']
+  ])('skips %s', (href) => {
+    expect(resolveTarget(page, href)).toBeNull()
+  })
+})
+
+describe('findBrokenAnchors', () => {
+  it('passes a site whose anchors all resolve', () => {
+    const result = findBrokenAnchors(siteDir)
+
+    expect(result.problems).toEqual([])
+    expect(result.checked).toBe(1)
+    expect(result.pages).toBe(2)
+  })
+
+  it('catches a wrong anchor on a page that does exist', () => {
+    // The whole reason this script exists: Antora resolves the page and says nothing.
+    writePage('docs/1.0/a.html', '<a href="b.html#typo">to b</a>')
+
+    const { problems } = findBrokenAnchors(siteDir)
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].href).toBe('b.html#typo')
+    expect(problems[0].reason).toContain('no id="typo"')
+    expect(problems[0].reason).toContain('b.html')
+  })
+
+  it('catches a dangling fragment-only link and names the page itself', () => {
+    writePage('docs/1.0/a.html', '<a href="#nowhere">here</a>')
+
+    const { problems } = findBrokenAnchors(siteDir)
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].reason).toBe('no id="nowhere" in this page')
+  })
+
+  it('reports a missing target page separately from a missing anchor', () => {
+    writePage('docs/1.0/a.html', '<a href="gone.html#target">gone</a>')
+
+    const { problems } = findBrokenAnchors(siteDir)
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].reason).toContain('target page not found')
+  })
+
+  it('ignores the UI bundle assets under _', () => {
+    writePage('_/js/vendor.html', '<a href="#not-our-problem">x</a>')
+
+    expect(findBrokenAnchors(siteDir).problems).toEqual([])
+    expect(findBrokenAnchors(siteDir).pages).toBe(2)
+  })
+
+  it('tolerates a page with no article element, such as the redirect stub', () => {
+    // Antora writes a bare redirect page at the site root; it has no <article>, which
+    // is why this checks whole pages instead of scoping to one element.
+    writePage('index.html', '<h1>Redirect Notice</h1><a href="docs/1.0/a.html">go</a>')
+
+    expect(findBrokenAnchors(siteDir).problems).toEqual([])
+  })
+
+  it('explains itself when the site has not been built', () => {
+    expect(() => findBrokenAnchors(path.join(siteDir, 'absent'))).toThrow(/npm run docs/)
+  })
+})

--- a/src/test/docs/validate_xrefs.spec.ts
+++ b/src/test/docs/validate_xrefs.spec.ts
@@ -1,0 +1,69 @@
+// The whole point of scripts/docs/validateXrefs.js is that Antora reports a dangling
+// internal reference at *info* level, which --log-failure-level cannot fail on, so
+// these tests pin the level-independent behaviour: a reference problem is a problem
+// whatever level Antora logged it at, and nothing else is.
+
+const { collectProblems } = require('../../../scripts/docs/validateXrefs')
+
+const record = (level: string, msg: string, file?: string) =>
+  JSON.stringify({ level, time: 1, name: 'asciidoctor', msg, ...(file ? { file: { path: file } } : {}) })
+
+describe('collectProblems', () => {
+  it('flags a dangling internal reference even though Antora logs it at info', () => {
+    const out = record('info', 'possible invalid reference: upgrade-dashboards', '/repo/docs/a.adoc')
+
+    expect(collectProblems(out)).toEqual([
+      { msg: 'possible invalid reference: upgrade-dashboards', file: '/repo/docs/a.adoc' }
+    ])
+  })
+
+  it.each([
+    ['error', 'target of xref not found: no-such-page.adoc'],
+    ['error', 'target of image not found: no-such-image.png'],
+    ['warn', 'target of include not found: no-such-include.adoc']
+  ])('flags %s: %s', (level, msg) => {
+    expect(collectProblems(record(level, msg, '/repo/docs/a.adoc'))).toHaveLength(1)
+  })
+
+  it('collects every problem, not just the first', () => {
+    const out = [
+      record('info', 'possible invalid reference: one', '/repo/docs/a.adoc'),
+      record('error', 'target of xref not found: two.adoc', '/repo/docs/b.adoc')
+    ].join('\n')
+
+    expect(collectProblems(out).map((p: { file: string }) => p.file)).toEqual([
+      '/repo/docs/a.adoc',
+      '/repo/docs/b.adoc'
+    ])
+  })
+
+  it('ignores unrelated messages at any level', () => {
+    const out = [
+      record('info', 'Using generator: @antora/xref-validator'),
+      record('warn', 'the page reached its limit'),
+      record('error', 'something else entirely')
+    ].join('\n')
+
+    expect(collectProblems(out)).toEqual([])
+  })
+
+  it('survives non-JSON lines and empty output', () => {
+    const out = ['added 36 packages in 5s', '', record('info', 'possible invalid reference: x')].join('\n')
+
+    expect(collectProblems(out)).toHaveLength(1)
+    expect(collectProblems('')).toEqual([])
+    expect(collectProblems(undefined)).toEqual([])
+  })
+
+  it('reports a missing file path rather than throwing', () => {
+    expect(collectProblems(record('info', 'possible invalid reference: x'))).toEqual([
+      { msg: 'possible invalid reference: x', file: '<unknown file>' }
+    ])
+  })
+
+  it('does not flag a message that merely mentions a reference problem mid-sentence', () => {
+    const out = record('info', 'checked for possible invalid reference targets', '/repo/docs/a.adoc')
+
+    expect(collectProblems(out)).toEqual([])
+  })
+})

--- a/src/test/docs/validate_xrefs.spec.ts
+++ b/src/test/docs/validate_xrefs.spec.ts
@@ -3,7 +3,11 @@
 // these tests pin the level-independent behaviour: a reference problem is a problem
 // whatever level Antora logged it at, and nothing else is.
 
-const { collectProblems } = require('../../../scripts/docs/validateXrefs')
+const {
+  collectProblems,
+  describeLocation,
+  UNKNOWN_FILE
+} = require('../../../scripts/docs/validateXrefs')
 
 const record = (level: string, msg: string, file?: string) =>
   JSON.stringify({ level, time: 1, name: 'asciidoctor', msg, ...(file ? { file: { path: file } } : {}) })
@@ -65,5 +69,18 @@ describe('collectProblems', () => {
     const out = record('info', 'checked for possible invalid reference targets', '/repo/docs/a.adoc')
 
     expect(collectProblems(out)).toEqual([])
+  })
+})
+
+describe('describeLocation', () => {
+  it('relativises a real path against the project directory', () => {
+    expect(describeLocation('/repo/docs/a.adoc', '/repo')).toBe('docs/a.adoc')
+  })
+
+  it('leaves the unknown-file sentinel alone', () => {
+    // path.relative would resolve it against the cwd and print something like
+    // ../../../elsewhere/<unknown file> whenever the script runs from outside the repo.
+    expect(describeLocation(UNKNOWN_FILE, '/repo')).toBe(UNKNOWN_FILE)
+    expect(describeLocation(UNKNOWN_FILE, '/some/other/place')).toBe(UNKNOWN_FILE)
   })
 })


### PR DESCRIPTION
# OPG-500: Move CI to newer base images

Moves the CI packaging and docs jobs onto currently maintained base images, then fixes what
that exposed: the docs build has been failing, and xref validation has never actually gated
anything.

Five commits:

- Move CI to current base images and fix the docs build
- Make xref validation strict and fix a broken cross-page reference
- Validate that xref anchors exist, not just the pages they live on
- Install node dependencies in `build-docs`
- Address review findings in the docs validators and the RPM job

## 1. The base images

`opennms/build-env` has had no RPM- or Debian-family push since **November 2023**. Its newest
RHEL-family tag is CentOS 8 with **Node 16**; its newest Debian tag is bullseye with **Node
18**. Both are well below this repo's `engines` (`>=22 <25`), which is what was breaking the
deb build.

| executor | was | now |
|---|---|---|
| `build-executor-centos` → `rpm-build-executor` | `opennms/build-env:11.0.14_9-3.8.7-b9528` (CentOS 8, Node 16) | `rockylinux/rockylinux:9` |
| `build-executor-debian` → `deb-build-executor` | `opennms/build-env:debian-jdk11-b10453` (Debian 11, Node 18) | `node:22-trixie` (Debian 13) |
| `node-executor` | `cimg/node:22.22` | `cimg/node:22.23.2` |
| `docs-executor` | `opennms/antora:3.1.4-b10433` | **removed** — see §2 |

`make-tarball` and `make-zip` moved to `node-executor`. They need only node, `tar` and `zip`,
all present in `cimg/node`, so there was no reason to install node into Rocky for them. That
also stops `package:zip` running under Node 16.

Three things needed handling that aren't obvious from the diff:

- **`sign-packages/install-deb-dependencies` breaks on modern Debian.** 
  `make-deb` now runs a plain `apt-get update` first (it needs `debhelper` anyway); the orb
  passes `-o APT::Get::List-Cleanup=0`, so those lists survive into its own call.

- **Rocky 9 carries no `nodejs`**, so `nodejs npm rpm-build` are installed explicitly
  (`rpm-sign` comes from the signing orb). `tar`, which the spec's `%setup` shells out to,
  needs no listing — it is in the base image *and* a declared dependency of `rpm-build`.

- The `vault.centos.org` repo rewrite in `make-rpm` is gone — it was a workaround for CentOS
  8's dead mirrors and is meaningless on Rocky.

## 2. The docs build was failing

`build-docs` has been dying with:

```
"msg":"Generator not found or failed to load. Try installing the '@antora/site-generator' package."
"message":"diagChan.tracingChannel is not a function"  at node_modules/pino/lib/tools.js:32
```
`docs-executor` has now been removed and `build-docs` runs on `node-executor` using this repo's own `@antora` devDependencies, bumped
`^3.1.14` → **`^3.2.0`** (the current `latest`; everything above it is `3.2.0-rc.*`).

`@antora/xref-validator` was the one thing genuinely holding us to the old image — it isn't on
npmjs.org, only a GitLab tarball. 

`npm run validate-xrefs` now installs it itself into a gitignored `.antora-tools/`.

The docs UI bundle now comes from `OpenNMS/antora-ui-opennms` **v3.1.1**, matching
`antora-playbook-local.yml` in the main OpenNMS repo. The old `opennms-forge` bundle is a
different repo whose newest release is v3.1.0 from 2022. To be clear, the bundle is only
presentation assets — it has **no** bearing on the Node/Antora problem above; swapping it
alone reproduces the identical crash.

## 3. Xref validation never gated anything

Antora's default `failure_level` is **`fatal`**, so a broken xref logged at `error` was
*reported* and the command still **exited 0**. The "Validate Xrefs in docs" step has been
decorative all along.

Both `validate-xrefs` and `docs` now pass `--log-failure-level=warn`, which covers warn and
above — missing images and includes too, not just xrefs.

That isn't sufficient on its own. Asciidoctor reports a **dangling internal reference** —
`<<some-anchor>>` where that anchor isn't on the page — at **`info`**, and `failure_level`
accepts only `warn|error|fatal|none`, so that class can never fail on Antora's exit code.
`scripts/docs/validateXrefs.js` wraps the validator, runs it at
`--log-level=info --log-format=json`, and fails on any reference message whatever level it was
logged at.

**That gap is how a real bug survived:** `getting_started/importing.adoc` linked to
`<<upgrade-dashboards>>`, an anchor that lives on `installation/upgrading.adoc`. It rendered as
`href="#upgrade-dashboards"` on a page with no such anchor — a link to nowhere. Now a proper
`xref:installation:upgrading.adoc#upgrade-dashboards[...]`.

## 4. Anchors are now validated too

Antora validates the *page* half of an xref target and **never** the `#anchor` half, so
`xref:installation:upgrading.adoc#typo[]` resolves the page, renders a link to nowhere and
reports nothing at any log level. `scripts/docs/validateAnchors.js` closes that, running as a
third `build-docs` step because it reads the site `npm run docs` builds.

One deliberate limitation: **root-relative hrefs are skipped.** Doing it properly needs
`site.url`, which this script deliberately doesn't read; Antora emits these only for UI assets
and the 404 page, never with a fragment. Leaving as is for now.

## 5. Updated `opennms-js` to `2.7.0`

Updated the `opennms` dependency to `2.7.0`. This removed some high/critical security vulnerabilities, most
noticeably with the removal of `fs`.

There's still a few `typecheck` errors in `opennms-js`, pretty minor ones, that weren't caught in time of the `2.7.0` release. We'll fix them in a subsequent release.

## Pre-existing issues, deliberately not fixed here

- `npm run typecheck` fails with 7 errors, down from 11. These are all in `opennms-js`. We'll eventually fix these there and have a new build.
- `osv-scanner` reports 2 medium vulnerabilities. The `opennms-js` upgrade to `2.7.0` removed some high/critical ones.

----------

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-500
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
